### PR TITLE
(DOCSP-10354): Landing page

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -6,7 +6,7 @@ intersphinx = ["https://docs.mongodb.com/manual/objects.inv"]
 toc_landing_pages = []
 
 [constants]
-mdb-shell = "MongoDB Shell"
+mdb-shell = "The MongoDB Shell"
 
 [substitutions]
 
@@ -70,6 +70,7 @@ kmip = ":abbr:`KMIP (Key Management Interoperability)`"
 kms = ":abbr:`KMS (Key Management Service)`"
 ldaps = ":abbr:`LDAPS (Secure Lightweight Directory Access Protocol)`"
 ldap = ":abbr:`LDAP (Lightweight Directory Access Protocol)`"
+mdb-shell= "MongoDB Shell"
 mms-full = "MongoDB Cloud Manager"
 mms = "Cloud Manager"
 mongo = ":binary:`~bin.mongo`"

--- a/source/includes/admonitions/fact-mdb-shell-beta.rst
+++ b/source/includes/admonitions/fact-mdb-shell-beta.rst
@@ -1,0 +1,6 @@
+.. admonition:: Beta
+   :class: note
+
+   |mdb-shell| is currently available as a **Beta** release. The
+   product, its features, and the corresponding documentation may
+   change during the Beta stage.

--- a/source/index.txt
+++ b/source/index.txt
@@ -45,8 +45,8 @@ Download and Install the |mdb-shell|
 Multi-Line Operations in the |mdb-shell|
 ----------------------------------------
 
-Run the ``editor()`` command inside of the |mdb-shell| to open the
-editor and manage comprehensive multiline functions:
+Run the ``.editor`` command within the |mdb-shell| to open the editor
+and manage comprehensive multiline functions:
 
 .. example::
 
@@ -54,11 +54,12 @@ editor and manage comprehensive multiline functions:
 
    .. code-block:: javascript
 
-      editor()
+      .editor
 
    The |mdb-shell| enters editor mode:
 
    .. code-block:: javascript
+      :copyable: false
 
       // Entering editor mode (^D to finish, ^C to cancel)
       const { Writable } = require('stream');
@@ -72,10 +73,18 @@ editor and manage comprehensive multiline functions:
           }
         });
 
+- Press ``Cmd/Ctrl`` + ``d`` to finish and run your function.
+
+- Press ``Cmd/Ctrl`` + ``c`` to cancel and exit without running your
+  function.
+
+When you close the editor, the |mdb-shell| does not save any functions
+you had entered into the editor.
+
 .. note::
 
-   Currently, ``editor()`` is the only way to run multiline commands in
-   the |mdb-shell|.
+   Currently, ``editor()`` is the only way to paste multiline commands
+   into the |mdb-shell|.
 
 
 Comparison of the |mdb-shell| and Legacy ``mongo`` Shell

--- a/source/index.txt
+++ b/source/index.txt
@@ -14,10 +14,9 @@ MongoDB Shell
 
 .. include:: /includes/admonitions/fact-mdb-shell-beta.rst
 
-The |mdb-shell| is an interactive JavaScript shell interface to MongoDB,
-which provides a powerful interface for users to test queries and
-operations directly with the database. The |mdb-shell| also provides a
-fully functional JavaScript environment for use with MongoDB.
+The |mdb-shell| is a fully functional JavaScript environment for
+interacting with MongoDB deployments. You can use the |mdb-shell| to
+test queries and operations directly with your database.
 
 The |mdb-shell| is available as a standalone package in the MongoDB
 download center.
@@ -87,8 +86,8 @@ you had entered into the editor.
    into the |mdb-shell|.
 
 
-Comparison of the |mdb-shell| and Legacy ``mongo`` Shell
---------------------------------------------------------
+The |mdb-shell| versus the Legacy ``mongo`` Shell
+-------------------------------------------------
 
 The |mdb-shell| offers numerous advantages over the legacy
 :binary:`mongo <mongo>` shell, such as:
@@ -99,7 +98,7 @@ The |mdb-shell| offers numerous advantages over the legacy
 
 - Improved logging.
 
-During the beta phase, the |mdb-shell| supports a subset of the legacy
+During the beta stage, the |mdb-shell| supports a subset of the legacy
 :binary:`mongo <mongo>` shell commands. Extending the |mdb-shell| |api|
 coverage is an ongoing effort.
 

--- a/source/index.txt
+++ b/source/index.txt
@@ -1,3 +1,5 @@
+.. _mdb-shell-overview:
+
 =============
 MongoDB Shell
 =============
@@ -9,6 +11,96 @@ MongoDB Shell
    :backlinks: none
    :depth: 1
    :class: singlecol
+
+.. include:: /includes/admonitions/fact-mdb-shell-beta.rst
+
+The |mdb-shell| is an interactive JavaScript shell interface to MongoDB,
+which provides a powerful interface for users to test queries and
+operations directly with the database. The |mdb-shell| also provides a
+fully functional JavaScript environment for use with MongoDB.
+
+The |mdb-shell| is available as a standalone package in the MongoDB
+download center.
+
+Download and Install the |mdb-shell|
+------------------------------------
+
+.. tabs-platforms::
+
+   .. tab::
+      :tabid: windows
+
+      Hello, I am Windows content.
+
+   .. tab::
+      :tabid: macOS
+
+      Hello, I am macOS content.
+
+   .. tab::
+      :tabid: linux
+      
+      Hello, I am Linux (rpm / deb) content.
+
+Multi-Line Operations in the |mdb-shell|
+----------------------------------------
+
+Run the ``editor()`` command inside of the |mdb-shell| to open the
+editor and manage comprehensive multiline functions:
+
+.. example::
+
+   Run the following command within the |mdb-shell|:
+
+   .. code-block:: javascript
+
+      editor()
+
+   The |mdb-shell| enters editor mode:
+
+   .. code-block:: javascript
+
+      // Entering editor mode (^D to finish, ^C to cancel)
+      const { Writable } = require('stream');
+
+        const myWritable = new Writable({
+          write(chunk, encoding, callback) {
+            // ...
+          },
+          writev(chunks, callback) {
+            // ...
+          }
+        });
+
+.. note::
+
+   Currently, ``editor()`` is the only way to run multiline commands in
+   the |mdb-shell|.
+
+
+Comparison of the |mdb-shell| and Legacy ``mongo`` Shell
+--------------------------------------------------------
+
+The |mdb-shell| offers numerous advantages over the legacy
+:binary:`mongo <mongo>` shell, such as:
+
+- Improved syntax highlighting.
+
+- Improved command history.
+
+- Improved logging.
+
+During the beta phase, the |mdb-shell| supports a subset of the legacy
+:binary:`mongo <mongo>` shell commands. Extending the |mdb-shell| |api|
+coverage is an ongoing effort.
+
+The commands that the |mdb-shell| supports use the same syntax as the
+corresponding commands in the legacy :binary:`mongo <mongo>` shell.
+
+Learn More
+----------
+
+.. This will effectively be a ToC linking out to other parts of the docs
 
 .. class:: hidden
 


### PR DESCRIPTION
Hey @mmarcon, I'd appreciate your eyes on this first draft of the landing page for the MongoDB Shell.

Some notes for context:

- This content is largely modeled after the [existing shell docs](https://docs.mongodb.com/manual/mongo/)

- We will be handling the download / installation instructions in a separate ticket, as well as fleshing out the "Learn More" section at a later date.

- Included in this draft is a skeleton for how we want to shape the rest of the docs. Even though we are linking out to the existing manual docs for command reference, I think it would be helpful to include a baseline "Getting Started" with basic CRUD / aggregation.

Some questions:

1. Just confirming the product name is "MongoDB Shell"? Asking because in the [product wiki](https://github.com/mongodb-js/mongosh/wiki) it is `mongosh`. If we want to call it `mongosh`, it's an easy fix.

2. Is there anything else we should call out / highlight on this page?

3. Looking for specific feedback on the [Comparison section](https://docs-mongodbcom-staging.corp.mongodb.com/ac7ecc3/mongodb-shell/docsworker/DOCSP-10354/#comparison-of-the-mdb-shell-and-legacy-mongo-shell), and if there is anything else we want to say there.

**Staged**: [MongoDB Shell](https://docs-mongodbcom-staging.corp.mongodb.com/266ebf3/mongodb-shell/docsworker/DOCSP-10354/)