### PR TITLE
(DOCSP-10363): Add available methods

### DIFF
--- a/source/reference.txt
+++ b/source/reference.txt
@@ -10,5 +10,5 @@ Reference
       :titlesonly:
 
       /reference/settings
-      /reference/commands
+      /reference/methods
       /reference/logging

--- a/source/reference/commands.txt
+++ b/source/reference/commands.txt
@@ -1,9 +1,0 @@
-=======================================
-Available Commands in the MongoDB Shell
-=======================================
-
-.. contents:: On this page
-   :local:
-   :backlinks: none
-   :depth: 1
-   :class: singlecol

--- a/source/reference/methods.txt
+++ b/source/reference/methods.txt
@@ -1,0 +1,410 @@
+.. _mdb-shell-methods:
+
+=====================
+MongoDB Shell Methods
+=====================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+.. include:: /includes/admonitions/fact-mdb-shell-beta.rst
+
+The following document lists the available methods in the |mdb-shell|.
+Click a method to see its documentation in the
+:manual:`MongoDB Manual </>`, including syntax and examples.
+
+Collection Methods
+------------------
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Name
+
+     - Description
+
+   * - :method:`db.collection.aggregate()`
+
+     - Provides access to the
+       :manual:`aggregation pipeline </core/aggregation-pipeline>`.
+
+   * - :method:`db.collection.bulkWrite()`
+
+     - Provides bulk write operation functionality.
+
+       .. convertToCapped
+
+   * - :method:`db.collection.count()`
+
+     - Returns a count of the number of documents in a collection or a
+       view.
+
+   * - :method:`db.collection.countDocuments()`
+
+     - Returns a count of the number of documents in a collection or a
+       view. Wraps the :pipeline:`$group` aggregation stage with a
+       :group:`$sum` expression.
+   
+   * - :method:`db.collection.estimatedDocumentCount()`
+
+     - Returns an approximate count of the documents in a collection or
+       a view.
+
+   * - :method:`db.collection.createIndex()`
+
+     - Builds an index on a collection.
+
+   * - :method:`db.collection.createIndexes()`
+
+     - Builds one or more indexes on a collection.
+
+   * - :method:`db.collection.dataSize()`
+
+     - Returns the size of the collection. Wraps the
+       :data:`~collStats.size` field in the output of the
+       :dbcommand:`collStats`.
+
+   * - :method:`db.collection.deleteOne()`
+
+     - Deletes a single document in a collection.
+
+   * - :method:`db.collection.deleteMany()`
+
+     - Deletes multiple documents in a collection.
+
+   * - :method:`db.collection.distinct()`
+
+     - Returns an array of documents that have distinct values for the
+       specified field.
+
+   * - :method:`db.collection.drop()`
+
+     - Removes the specified collection from the database.
+
+   * - :method:`db.collection.dropIndex()`
+
+     - Removes a specified index on a collection.
+
+   * - :method:`db.collection.dropIndexes()`
+
+     - Removes all indexes on a collection.
+
+   * - :method:`db.collection.ensureIndex()`
+
+     - Deprecated. Use :method:`db.collection.createIndex()`.
+
+       .. exists
+
+   * - :method:`db.collection.explain()`
+
+     - Returns information on the query execution of various methods.
+
+   * - :method:`db.collection.find()`
+
+     - Performs a query on a collection or a view and returns a cursor
+       object.
+
+   * - :method:`db.collection.findAndModify()`
+
+     - Atomically modifies and returns a single document.
+
+   * - :method:`db.collection.findOne()`
+
+     - Performs a query and returns a single document.
+
+   * - :method:`db.collection.findOneAndDelete()`
+
+     - Finds a single document and deletes it.
+
+   * - :method:`db.collection.findOneAndReplace()`
+
+     - Finds a single document and replaces it.
+
+   * - :method:`db.collection.findOneAndUpdate()`
+
+     - Finds a single document and updates it.
+
+   * - :method:`db.collection.getIndexes()`
+
+     - Returns an array of documents that describe the existing indexes
+       on a collection.
+
+       .. getIndexKeys
+
+       .. getIndexSpecs
+
+   * - :method:`db.collection.insert()`
+
+     - Creates a new document in a collection.
+
+   * - :method:`db.collection.insertOne()`
+
+     - Inserts a new document in a collection.
+
+   * - :method:`db.collection.insertMany()`
+
+     - Inserts several new document in a collection.
+
+   * - :method:`db.collection.isCapped()`
+
+     - Reports if a collection is a :term:`capped collection`.
+
+   * - :method:`db.collection.reIndex()`
+
+     - Rebuilds all existing indexes on a collection.
+
+   * - :method:`db.collection.remove()`
+
+     - Deletes documents from a collection.
+
+   * - :method:`db.collection.renameCollection()`
+
+     - Changes the name of a collection.
+
+   * - :method:`db.collection.replaceOne()`
+
+     - Replaces a single document in a collection.
+
+   * - :method:`db.collection.save()`
+
+     - Provides a wrapper around an :method:`~db.collection.insert()`
+       and :method:`~db.collection.update()` to insert new documents.
+
+   * - :method:`db.collection.stats()`
+
+     - Reports on the state of a collection. Provides a wrapper around
+       the :dbcommand:`collStats`.
+
+   * - :method:`db.collection.storageSize()`
+
+     - Reports the total size used by the collection in bytes. Provides
+       a wrapper around the :data:`~collStats.storageSize` field of the
+       :dbcommand:`collStats` output.
+
+   * - :method:`db.collection.totalIndexSize()`
+
+     - Reports the total size used by the indexes on a collection.
+       Provides a wrapper around the :data:`~collStats.totalIndexSize`
+       field of the :dbcommand:`collStats` output.
+
+   * - :method:`db.collection.totalSize()`
+
+     - Reports the total size of a collection, including the size of
+       all documents and all indexes on a collection.
+
+   * - :method:`db.collection.update()`
+
+     - Modifies a document in a collection.
+
+   * - :method:`db.collection.updateOne()`
+
+     - Modifies a single document in a collection.
+
+   * - :method:`db.collection.updateMany()`
+
+     - Modifies multiple documents in a collection.
+
+Cursor Methods
+--------------
+
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Name
+
+     - Description
+
+   * - :method:`cursor.addOption()`
+
+     - Adds special wire protocol flags that modify the behavior of the
+       query.
+
+   * - :method:`cursor.allowPartialResults()`
+
+     - Allows :method:`db.collection.find()` operations against a
+       sharded collection to return partial results, rather than an
+       error, if one or more queried shards are unavailable.
+
+       .. arrayAccess
+
+   * - :method:`cursor.batchSize()`
+
+     - Controls the number of documents MongoDB will return to the
+       client in a single network message.
+
+       .. clone
+
+   * - :method:`cursor.close()`
+
+     - Close a cursor and free associated server resources.
+
+   * - :method:`cursor.collation()`
+
+     - Specifies the collation for the cursor returned by the
+       :method:`db.collection.find()`.
+
+   * - :method:`cursor.comment()`
+
+     - Attaches a comment to the query to allow for traceability in the
+       logs and the system.profile collection.
+
+   * - :method:`cursor.count()`
+
+     - Modifies the cursor to return the number of documents in the
+       result set rather than the documents themselves.
+
+   * - :method:`cursor.explain()`
+
+     - Reports on the query execution plan for a cursor.
+
+   * - :method:`cursor.forEach()`
+
+     - Applies a JavaScript function for every document in a cursor.
+
+   * - :method:`cursor.hasNext()`
+
+     - Returns ``true`` if the cursor has documents and can be iterated.
+
+   * - :method:`cursor.hint()`
+
+     - Forces MongoDB to use a specific index for a query.
+
+   * - :method:`cursor.isClosed()`
+
+     - Returns ``true`` if the cursor is closed.
+
+   * - :method:`cursor.isExhausted()`
+
+     - Returns ``true`` if the cursor is closed *and* there are no
+       objects remaining in the batch.
+
+   * - :method:`cursor.itcount()`
+
+     - Computes the total number of documents in the cursor client-side
+       by fetching and iterating the result set.
+
+   * - :method:`cursor.limit()`
+
+     - Constrains the size of a cursor's result set.
+
+   * - :method:`cursor.map()`
+
+     - Applies a function to each document in a cursor and collects the
+       return values in an array.
+
+   * - :method:`cursor.max()`
+
+     - Specifies an exclusive upper index bound for a cursor. For use
+       with :method:`cursor.hint()`
+
+   * - :method:`cursor.maxTimeMS()`
+
+     - Specifies a cumulative time limit in milliseconds for processing
+       operations on a cursor.
+
+   * - :method:`cursor.min()`
+
+     - Specifies an inclusive lower index bound for a cursor. For use
+       with :method:`cursor.hint()`
+
+   * - :method:`cursor.next()`
+
+     - Returns the next document in a cursor.
+
+   * - :method:`cursor.noCursorTimeout()`
+
+     - Instructs the server to avoid closing a cursor automatically
+       after a period of inactivity.
+
+       .. oplogReplay
+
+       .. projection
+
+   * - :method:`cursor.readPref()`
+
+     - Specifies a :term:`read preference` to a cursor to control how
+       the client directs queries to a :term:`replica set`.
+
+   * - :method:`cursor.returnKey()`
+
+     - Modifies the cursor to return index keys rather than the
+       documents.
+
+   * - :method:`cursor.size()`
+
+     - Returns a count of the documents in the cursor after applying
+       :method:`~cursor.skip()` and :method:`~cursor.limit()` methods.
+
+   * - :method:`cursor.skip()`
+
+     - Returns a cursor that begins returning results only after
+       passing or skipping a number of documents.
+
+   * - :method:`cursor.sort()`
+
+     - Returns results ordered according to a sort specification.
+
+   * - :method:`cursor.tailable()`
+
+     - Marks the cursor as tailable. Only valid for cursors over capped 
+       collections.
+
+   * - :method:`cursor.toArray()`
+
+     - Returns an array that contains all documents returned by the
+       cursor.
+
+Database Methods
+----------------
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Name
+
+     - Description
+
+   * - :method:`db.adminCommand()`
+
+     - Runs a command against the ``admin`` database.
+
+   * - :method:`db.aggregate()`
+
+     - Runs admin/diagnostic pipeline which does not require an underlying collection.
+
+   * - :method:`db.dropDatabase()`
+
+     - Removes the current database.
+
+   * - :method:`db.getCollection()`
+
+     - Returns a collection or view object. Used to access collections
+       with names that are not valid in the :binary:`~bin.mongo` shell.
+
+   * - :method:`db.getCollectionInfos()`
+
+     - Returns collection information for all collections and views in
+       the current database.
+
+   * - :method:`db.getCollectionNames()`
+
+     - Lists all collections and views in the current database.
+
+   * - :method:`db.getName()`
+
+     - Returns the name of the current database.
+
+   * - :method:`db.getSiblingDB()`
+
+     - Provides access to the specified database.
+
+   * - :method:`db.runCommand()`
+
+     - Runs a :manual:`database command </reference/command>`.


### PR DESCRIPTION
Staged: [Available Methods](https://docs-mongodbcom-staging.corp.mongodb.com/eb3d0c6/mongodb-shell/docsworker/DOCSP-10363/reference/methods)

Hey @mmarcon, in looking at the [output of the available new shell methods](https://mongodb.slack.com/files/UD96QJACS/F014EKV00BA/untitled?origin_team=T024FNNHU&origin_channel=Vall_threads) there are some methods in the output which we do not document on the [legacy mongo shell docs](https://docs.mongodb.com/manual/reference/method/).

I wanted to list them here just to see if they were maybe new methods, or wrappers for some other method?

* Collection Methods
  * convertToCapped (this looks to be a [command](https://docs.mongodb.com/manual/reference/command/convertToCapped/), so I'm wondering if there is now a wrapper for this command?)
  * exists
  * getIndexKeys
  * getIndexSpecs

* Cursor Methods
  * arrayAccess
  * clone
  * oplogReplay
  * projection
