### PR TITLE
(DOCSP-10356) Windows install procedure

### DIFF
--- a/source/includes/steps-install-shell-windows.yaml
+++ b/source/includes/steps-install-shell-windows.yaml
@@ -18,24 +18,8 @@ title: "Extract the files from the downloaded archive."
 ref: extract-archive
 level: 4
 content: |
-   
-   To extract files from a ``.zip`` folder:
-
-   1. Right click on the folder you want to extract files from.
-
-   #. Select :guilabel:`Extract All...`
-
-   #. Choose a file destination to which the folder's contents are 
-      extracted. The default destination is the same directory as the 
-      ``.zip`` folder.
-
-   #. Click :guilabel:`Extract`.
-
-   The contents of the ``.zip`` folder are extracted to the specified 
-   destination.
-
-   Skip this step if your web browser automatically unzips the file as
-   part of the download.
+   Extract the ``mongosh`` file to a destination that your ``PATH`` 
+   environment variable accesses or can be configured to access.
 ---
 title: "Add the MongoDB Shell binary to your ``PATH`` environment
    variable."
@@ -43,7 +27,9 @@ ref: add-shell-to-path
 level: 4
 content: |
 
-   To add the |mdb-shell| binary to your ``PATH`` environment:
+   If your ``PATH`` environment variable is not already configured to 
+   find ``mongosh``, add the |mdb-shell| binary's location to your 
+   ``PATH`` environment variable:
 
    1. Open the :guilabel:`Control Panel`.
 
@@ -55,7 +41,7 @@ content: |
 
    #. Click :guilabel:`Environment Variables`.
 
-   #. In the *User variables* section, select ``Path`` and click 
+   #. In the *System variables* section, select ``Path`` and click 
       :guilabel:`Edit`. The **Edit environment variable** modal 
       displays.
 
@@ -66,8 +52,9 @@ content: |
       modal, click :guilabel:`OK` to confirm your changes.
 
    To confirm that your ``PATH`` environment variable is correctly 
-   configured with ``mongosh``, search for ``cmd`` to open a command 
-   prompt and enter the ``mongosh --help`` command. If your ``PATH`` is 
-   configured correctly, a list of valid commands displays.
+   configured to find ``mongosh``, use the search bar to search for 
+   ``cmd``, open a command prompt, and enter the ``mongosh --help`` 
+   command. If your ``PATH`` is configured correctly, a list of valid 
+   commands displays.
 
 ...

--- a/source/includes/steps-install-shell-windows.yaml
+++ b/source/includes/steps-install-shell-windows.yaml
@@ -23,5 +23,9 @@ source:
   file: steps-install-shell-base.yaml
   ref: add-shell-to-path
 ref: add-shell-to-path-windows
-
+---
+source:
+  file: steps-install-shell-base.yaml
+  ref: add-shell-to-path
+ref: add-shell-to-path-windows
 ...

--- a/source/includes/steps-install-shell-windows.yaml
+++ b/source/includes/steps-install-shell-windows.yaml
@@ -17,15 +17,16 @@ ref: download-archive-windows
 title: "Extract the files from the downloaded archive."
 ref: extract-archive
 level: 4
-content: |
-   Skip this step if your web browser automatically unzips the file as
-   part of the download.
 ---
 title: "Add the MongoDB Shell binary to your ``PATH`` environment
    variable."
 ref: add-shell-to-path
 level: 4
 content: |
+
+   Ensure that the extracted |mdb-shell| binary is in the desired 
+   location in your filesystem, then add that location to your ``PATH`` 
+   environment variable.
 
    To add the |mdb-shell| binary's location to your 
    ``PATH`` environment variable:
@@ -45,7 +46,7 @@ content: |
       displays.
 
    #. Click :guilabel:`New` and add the filepath to your ``mongosh`` 
-      executable.
+      binary.
 
    #. Click :guilabel:`OK` to confirm your changes. On each other 
       modal, click :guilabel:`OK` to confirm your changes.

--- a/source/includes/steps-install-shell-windows.yaml
+++ b/source/includes/steps-install-shell-windows.yaml
@@ -52,9 +52,8 @@ content: |
       modal, click :guilabel:`OK` to confirm your changes.
 
    To confirm that your ``PATH`` environment variable is correctly 
-   configured to find ``mongosh``, use the search bar to search for 
-   ``cmd``, open a command prompt, and enter the ``mongosh --help`` 
-   command. If your ``PATH`` is configured correctly, a list of valid 
-   commands displays.
+   configured to find ``mongosh``, open a command prompt and enter the 
+   ``mongosh --help`` command. If your ``PATH`` is configured 
+   correctly, a list of valid commands displays.
 
 ...

--- a/source/includes/steps-install-shell-windows.yaml
+++ b/source/includes/steps-install-shell-windows.yaml
@@ -14,18 +14,56 @@ source:
   ref: download-archive
 ref: download-archive-windows
 ---
-source:
-  file: steps-install-shell-base.yaml
-  ref: extract-archive
-ref: extract-archive-windows
+title: "Extract the files from the downloaded archive."
+ref: extract-archive
+level: 4
+content: |
+   
+   To extract files from a ``.zip`` folder:
+
+   1. Right click on the folder you want to extract from.
+
+   #. Select :guilabel:`Extract All...`
+
+   #. Choose a file destination to which the folder's contents are 
+      extracted. The default destination is the same directory as the 
+      ``.zip`` folder.
+
+   #. Click :guilabel:`Extract`.
+
+   The contents of the ``.zip`` folder are extracted to the specified 
+   destination.
+
+   Skip this step if your web browser automatically unzips the file as
+   part of the download.
 ---
-source:
-  file: steps-install-shell-base.yaml
-  ref: add-shell-to-path
-ref: add-shell-to-path-windows
----
-source:
-  file: steps-install-shell-base.yaml
-  ref: add-shell-to-path
-ref: add-shell-to-path-windows
+title: "Add the MongoDB Shell binary to your ``PATH`` environment
+   variable."
+ref: add-shell-to-path
+level: 4
+content: |
+
+   To add the |mdb-shell| binary to your ``PATH`` environment:
+
+   1. Open the :guilabel:`Control Panel`.
+
+   #. Click :guilabel:`System and Security`.
+
+   #. Click :guilabel:`System`.
+
+   #. Click :guilabel:`Advanced system settings`. The *System 
+      Properties* modal displays.
+
+   #. Click :guilabel:`Environment Variables`.
+
+   #. Under *User variables*, select ``Path`` and click 
+      :guilabel:`Edit...`. The *Edit environment variable* modal 
+      displays.
+
+   #. Click :guilabel:`New` and add the path to your ``mongosh`` 
+      executable.
+
+   #. Click :guilabel:`OK` to confirm your changes. On each other 
+      modal, click :guilabel:`OK` to confirm your changes.
+
 ...

--- a/source/includes/steps-install-shell-windows.yaml
+++ b/source/includes/steps-install-shell-windows.yaml
@@ -1,0 +1,27 @@
+---
+source:
+  file: steps-install-shell-base.yaml
+  ref: navigate-dlc
+ref: navigate-dlc-windows
+---
+source:
+  file: steps-install-shell-base.yaml
+  ref: open-mdb-shell-page
+ref: open-mdb-shell-page-windows
+---
+source:
+  file: steps-install-shell-base.yaml
+  ref: download-archive
+ref: download-archive-windows
+---
+source:
+  file: steps-install-shell-base.yaml
+  ref: extract-archive
+ref: extract-archive-windows
+---
+source:
+  file: steps-install-shell-base.yaml
+  ref: add-shell-to-path
+ref: add-shell-to-path-windows
+
+...

--- a/source/includes/steps-install-shell-windows.yaml
+++ b/source/includes/steps-install-shell-windows.yaml
@@ -21,7 +21,7 @@ content: |
    
    To extract files from a ``.zip`` folder:
 
-   1. Right click on the folder you want to extract from.
+   1. Right click on the folder you want to extract files from.
 
    #. Select :guilabel:`Extract All...`
 
@@ -47,23 +47,27 @@ content: |
 
    1. Open the :guilabel:`Control Panel`.
 
-   #. Click :guilabel:`System and Security`.
+   #. In the :guilabel:`System and Security` category, click 
+      :guilabel:`System`.
 
-   #. Click :guilabel:`System`.
-
-   #. Click :guilabel:`Advanced system settings`. The *System 
-      Properties* modal displays.
+   #. Click :guilabel:`Advanced system settings`. The **System 
+      Properties** modal displays.
 
    #. Click :guilabel:`Environment Variables`.
 
-   #. Under *User variables*, select ``Path`` and click 
-      :guilabel:`Edit...`. The *Edit environment variable* modal 
+   #. In the *User variables* section, select ``Path`` and click 
+      :guilabel:`Edit`. The **Edit environment variable** modal 
       displays.
 
-   #. Click :guilabel:`New` and add the path to your ``mongosh`` 
+   #. Click :guilabel:`New` and add the filepath to your ``mongosh`` 
       executable.
 
    #. Click :guilabel:`OK` to confirm your changes. On each other 
       modal, click :guilabel:`OK` to confirm your changes.
+
+   To confirm that your ``PATH`` environment variable is correctly 
+   configured with ``mongosh``, search for ``cmd`` to open a command 
+   prompt and enter the ``mongosh --help`` command. If your ``PATH`` is 
+   configured correctly, a list of valid commands displays.
 
 ...

--- a/source/includes/steps-install-shell-windows.yaml
+++ b/source/includes/steps-install-shell-windows.yaml
@@ -18,8 +18,8 @@ title: "Extract the files from the downloaded archive."
 ref: extract-archive
 level: 4
 content: |
-   Extract the ``mongosh`` file to a destination that your ``PATH`` 
-   environment variable accesses or can be configured to access.
+   Skip this step if your web browser automatically unzips the file as
+   part of the download.
 ---
 title: "Add the MongoDB Shell binary to your ``PATH`` environment
    variable."
@@ -27,8 +27,7 @@ ref: add-shell-to-path
 level: 4
 content: |
 
-   If your ``PATH`` environment variable is not already configured to 
-   find ``mongosh``, add the |mdb-shell| binary's location to your 
+   To add the |mdb-shell| binary's location to your 
    ``PATH`` environment variable:
 
    1. Open the :guilabel:`Control Panel`.

--- a/source/index.txt
+++ b/source/index.txt
@@ -44,7 +44,7 @@ Procedure
    .. tab::
       :tabid: windows
 
-      Hello, I am Windows content.
+      .. include:: /includes/steps/install-shell-windows.rst
 
    .. tab::
       :tabid: macOS


### PR DESCRIPTION
[Ticket](https://jira.mongodb.org/browse/DOCSP-10356)
[Staged](https://docs-mongodbcom-staging.corp.mongodb.com/bb5b8b4/mongodb-shell/docsworker/DOCSP-10356/#download-and-install-the-mdb-shell)

Question for review: should there be an unzip procedure in step 4? I decided not to include one because unzipping can be done in many simple ways, including dragging the contents of the .zip folder out of the folder. Covering multiple Windows unzipping methods seems outside of scope and choosing one that works for all Windows versions overcomplicates later versions.

The procedure in step 5 covers Windows 10, 8, and 7. It's not very different for Vista and XP.