### PR TITLE
(DOCSP-10504): CRUD ops for mongosh

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -3,7 +3,7 @@ title = "MongoDB Shell"
 
 intersphinx = ["https://docs.mongodb.com/manual/objects.inv"]
 
-toc_landing_pages = []
+toc_landing_pages = ["/crud"]
 
 [constants]
 mdb-shell = "The MongoDB Shell"

--- a/source/crud.txt
+++ b/source/crud.txt
@@ -1,3 +1,70 @@
 =======================
 Perform CRUD Operations
 =======================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+.. include:: /includes/admonitions/fact-mdb-shell-beta.rst
+
+CRUD operations *create*, *read*, *update*, and *delete* documents.
+
+Create Operations
+-----------------
+
+Create or insert operations add new documents to a collection. If the
+collection does not currently exist, create operations create the
+collection.
+
+You can insert a single document or multiple documents in a single
+operation.
+
+For examples, see :ref:`mongosh-insert`.
+
+Read Operations
+---------------
+
+Read operations retrieves documents from a collection; i.e. queries a
+collection for documents.
+
+You can specify criteria, or filters, that identify the documents to
+return.
+
+For examples, see :ref:`mongosh-read`.
+
+Update Operations
+-----------------
+
+Update operations modify existing documents in a collection. You can
+update a single document or multiple documents in a single operation.
+
+You can specify criteria, or filters, that identify the documents to
+update. These filters use the same syntax as read operations.
+
+For examples, see :ref:`mongosh-update`.
+
+Delete Operations
+-----------------
+
+Delete operations remove existing documents from a collection. You can
+remove a single document or multiple documents in a single operation.
+
+You can specify criteria, or filters, that identify the documents to
+remove. These filters use the same syntax as read operations.
+
+For examples, see :ref:`mongosh-delete`.
+
+.. class:: hidden
+
+   .. toctree::
+      :titlesonly:
+
+      /crud/insert
+      /crud/read
+      /crud/update
+      /crud/delete

--- a/source/crud.txt
+++ b/source/crud.txt
@@ -18,7 +18,7 @@ Create Operations
 -----------------
 
 Create or insert operations add new documents to a collection. If the
-collection does not currently exist, create operations create the
+collection does not exist, create operations also create the
 collection.
 
 You can insert a single document or multiple documents in a single
@@ -29,7 +29,7 @@ For examples, see :ref:`mongosh-insert`.
 Read Operations
 ---------------
 
-Read operations retrieves documents from a collection; i.e. queries a
+Read operations retrieve documents from a collection; i.e. query a
 collection for documents.
 
 You can specify criteria, or filters, that identify the documents to

--- a/source/crud/delete.txt
+++ b/source/crud/delete.txt
@@ -1,0 +1,110 @@
+.. _mongosh-delete:
+
+================
+Delete Documents
+================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+.. include:: /includes/admonitions/fact-mdb-shell-beta.rst
+
+The MongoDB shell provides the following methods to delete documents
+from a collection:
+
+- To delete multiple documents, use
+  :method:`db.collection.deleteMany()`.
+
+- To delete a single document, use :method:`db.collection.deleteOne()`.
+
+.. include:: /includes/fact-sample-data-examples.rst
+
+Delete All Documents
+--------------------
+
+To delete all documents from a collection, pass an empty
+:ref:`filter<document-query-filter>` document ``{}`` to the
+:method:`db.collection.deleteMany()` method.
+
+.. example::
+
+   To delete all documents from the ``sample_mflix.movies`` collection:
+
+   .. code-block:: javascript
+
+      use sample_mflix
+
+      db.movies.deleteMany({})
+ 
+   The method returns a document with the status of the operation. For
+   more information and examples, see
+   :method:`~db.collection.deleteMany()`.
+
+Delete All Documents that Match a Condition
+-------------------------------------------
+
+You can specify criteria, or filters, that identify the documents to
+delete. The :ref:`filters <document-query-filter>` use the same syntax
+as read operations.
+
+To specify equality conditions, use ``<field>:<value>`` expressions in
+the query filter document.
+
+To delete all documents that match a deletion criteria, pass a filter
+parameter to the :method:`~db.collection.deleteMany()` method.
+
+.. example::
+
+   To delete all documents from the ``sample_mflix.movies`` collection
+   where the ``title`` equals ``"Titanic"``:
+
+   .. code-block:: javascript
+
+      use sample_mflix
+
+      db.movies.deleteMany( { title: "Titanic" } )
+
+   The method returns a document with the status of the operation. For
+   more information and examples, see
+   :method:`~db.collection.deleteMany()`.
+
+Delete Only One Document that Matches a Condition
+-------------------------------------------------
+
+To delete at most a single document that matches a specified filter
+(even though multiple documents may match the specified filter) use the
+:method:`db.collection.deleteOne()` method.
+
+.. example::
+
+   To delete the *first* document from the ``sample_mflix.movies``
+   collection where the ``cast`` array contains ``"Brad Pitt"``:
+
+   .. code-block:: javascript
+
+      use sample_mflix
+
+      db.movies.deleteOne( { cast: "Brad Pitt" } )
+
+Delete Behavior
+---------------
+
+To learn more about the specific behavior of deleting documents,
+see :manual:`Behavior </tutorial/remove-documents/#delete-behavior>`.
+
+Learn More
+----------
+
+- To see additional examples of deleting documents, see the following
+  method pages:
+
+  - :method:`db.collection.deleteMany()`
+  - :method:`db.collection.deleteOne()`
+
+- To see all available methods to delete documents, see
+  :manual:`Delete Methods </reference/delete-methods/>`.

--- a/source/crud/delete.txt
+++ b/source/crud/delete.txt
@@ -91,6 +91,8 @@ To delete at most a single document that matches a specified filter
 
       db.movies.deleteOne( { cast: "Brad Pitt" } )
 
+   .. include:: /includes/admonitions/note-natural-sort-order.rst
+
 Delete Behavior
 ---------------
 

--- a/source/crud/insert.txt
+++ b/source/crud/insert.txt
@@ -70,10 +70,10 @@ adds the ``_id`` field with an ObjectId value to each document. See
    ])
 
 :method:`~db.collection.insertMany()` returns a document that includes
-the newly inserted documents ``_id`` field values.
+the newly inserted documents' ``_id`` field values.
 
 To retrieve the inserted documents,
-:ref:`read the collection <mongosh-read>`:
+:ref:`read documents in the collection <mongosh-read>`:
 
 .. code-block:: javascript
  

--- a/source/crud/insert.txt
+++ b/source/crud/insert.txt
@@ -22,32 +22,52 @@ into a collection:
 - To insert multiple documents, use
   :method:`db.collection.insertMany()`.
 
+.. include:: /includes/fact-sample-data-examples.rst
+
 Insert a Single Document
 ------------------------
 
 :method:`db.collection.insertOne()` inserts a *single*
 :ref:`document<bson-document-format>` into a collection.
 
-The following example inserts a new document into the ``inventory``
-collection. If the document does not specify an ``_id`` field, MongoDB
-adds the ``_id`` field with an ObjectId value to the new document. See
-:ref:`write-op-insert-behavior`.
+.. example::
 
-.. code-block:: javascript
+  This example inserts a new document into the ``sample_mflix.movies``
+  collection. If the document does not specify an ``_id`` field, MongoDB
+  adds the ``_id`` field with an ObjectId value to the new document. See
+  :ref:`write-op-insert-behavior`.
 
-   db.inventory.insertOne(
-      { item: "canvas", qty: 100, tags: ["cotton"], size: { h: 28, w: 35.5, uom: "cm" } }
-   )
+  .. code-block:: javascript
 
-:method:`~db.collection.insertOne()` returns a document that
-includes the newly inserted document's ``_id`` field value.
+     use sample_mflix
 
-To retrieve the inserted document,
-:ref:`read the collection <mongosh-read>`:
+     db.movies.insertOne(
+       {
+         title: "The Favourite",
+         genres: [ "Drama", History" ]
+         runtime: 121,
+         rated: "R",
+         year: 2018,
+         directors: [ "Yorgos Lanthimos" ],
+         cast: [ "Olivia Colman", "Emma Stone", "Rachel Weisz" ],
+         type: "movie"
+       }
+     )
 
-.. code-block:: javascript
+   :method:`~db.collection.insertOne()` returns a document that
+   includes the newly inserted document's ``_id`` field value.
 
-   db.inventory.find( { item: "canvas" } )
+   To retrieve the inserted document,
+   :ref:`read the collection <mongosh-read>`:
+
+   .. code-block:: javascript
+
+      db.inventory.find( { title: "The Favourite" } )
+
+   .. note::
+
+      To ensure you return the document you inserted, you can instead
+      query by ``_id``.
 
 Insert Multiple Documents
 -------------------------
@@ -56,28 +76,44 @@ Insert Multiple Documents
 :ref:`documents <bson-document-format>` into a collection. Pass an array
 of documents to the method.
 
-The following example inserts three new documents into the ``inventory``
-collection. If the documents do not specify an ``_id`` field, MongoDB
-adds the ``_id`` field with an ObjectId value to each document. See
-:ref:`write-op-insert-behavior`.
+The following example inserts two new documents into the
+``sample_mflix.movies`` collection. If the documents do not specify an
+``_id`` field, MongoDB adds the ``_id`` field with an ObjectId value to
+each document. See :ref:`write-op-insert-behavior`.
 
 .. code-block:: javascript
 
    db.inventory.insertMany([
-      { item: "journal", qty: 25, tags: ["blank", "red"], size: { h: 14, w: 21, uom: "cm" } },
-      { item: "mat", qty: 85, tags: ["gray"], size: { h: 27.9, w: 35.5, uom: "cm" } },
-      { item: "mousepad", qty: 25, tags: ["gel", "blue"], size: { h: 19, w: 22.85, uom: "cm" } }
+      {
+         title: "Jurassic World: Fallen Kingdom",
+         genres: [ "Action", "Sci-Fi" ]
+         runtime: 130,
+         rated: "PG-13",
+         year: 2018,
+         directors: [ "J. A. Bayona" ],
+         cast: [ "Chris Pratt", "Bryce Dallas Howard", "Rafe Spall" ],
+         type: "movie"
+       },
+       {
+         title: "Tag",
+         genres: [ "Comedy", "Action" ]
+         runtime: 105,
+         rated: "R",
+         year: 2018,
+         directors: [ "Jeff Tomsic" ],
+         cast: [ "Annabelle Wallis", "Jeremy Renner", "Jon Hamm" ],
+         type: "movie"
+       }
    ])
 
 :method:`~db.collection.insertMany()` returns a document that includes
 the newly inserted documents' ``_id`` field values.
 
-To retrieve the inserted documents,
-:ref:`read documents in the collection <mongosh-read>`:
+To :ref:`read documents in the collection <mongosh-read>`:
 
 .. code-block:: javascript
  
-   db.inventory.find( {} )
+   db.movies.find( {} )
 
 Insert Behavior
 ---------------

--- a/source/crud/insert.txt
+++ b/source/crud/insert.txt
@@ -28,14 +28,14 @@ Insert a Single Document
 ------------------------
 
 :method:`db.collection.insertOne()` inserts a *single*
-:ref:`document<bson-document-format>` into a collection.
+:ref:`document<bson-document-format>` into a collection. If the document
+does not specify an ``_id`` field, MongoDB adds the ``_id`` field with
+an ObjectId value to the new document. See
+:ref:`write-op-insert-behavior`.
 
 .. example::
 
-  This example inserts a new document into the ``sample_mflix.movies``
-  collection. If the document does not specify an ``_id`` field, MongoDB
-  adds the ``_id`` field with an ObjectId value to the new document. See
-  :ref:`write-op-insert-behavior`.
+  To insert a new document into the ``sample_mflix.movies`` collection:
 
   .. code-block:: javascript
 
@@ -74,46 +74,50 @@ Insert Multiple Documents
 
 :method:`db.collection.insertMany()` can insert *multiple*
 :ref:`documents <bson-document-format>` into a collection. Pass an array
-of documents to the method.
+of documents to the method. If the documents do not specify an ``_id``
+field, MongoDB adds the ``_id`` field with an ObjectId value to each
+document. See :ref:`write-op-insert-behavior`.
 
-The following example inserts two new documents into the
-``sample_mflix.movies`` collection. If the documents do not specify an
-``_id`` field, MongoDB adds the ``_id`` field with an ObjectId value to
-each document. See :ref:`write-op-insert-behavior`.
+.. example::
 
-.. code-block:: javascript
+   To insert two new documents into the ``sample_mflix.movies``
+   collection:
 
-   db.inventory.insertMany([
-      {
-         title: "Jurassic World: Fallen Kingdom",
-         genres: [ "Action", "Sci-Fi" ]
-         runtime: 130,
-         rated: "PG-13",
-         year: 2018,
-         directors: [ "J. A. Bayona" ],
-         cast: [ "Chris Pratt", "Bryce Dallas Howard", "Rafe Spall" ],
-         type: "movie"
-       },
-       {
-         title: "Tag",
-         genres: [ "Comedy", "Action" ]
-         runtime: 105,
-         rated: "R",
-         year: 2018,
-         directors: [ "Jeff Tomsic" ],
-         cast: [ "Annabelle Wallis", "Jeremy Renner", "Jon Hamm" ],
-         type: "movie"
-       }
-   ])
+   .. code-block:: javascript
 
-:method:`~db.collection.insertMany()` returns a document that includes
-the newly inserted documents' ``_id`` field values.
+      use sample_mflix
 
-To :ref:`read documents in the collection <mongosh-read>`:
+      db.movies.insertMany([
+         {
+            title: "Jurassic World: Fallen Kingdom",
+            genres: [ "Action", "Sci-Fi" ],
+            runtime: 130,
+            rated: "PG-13",
+            year: 2018,
+            directors: [ "J. A. Bayona" ],
+            cast: [ "Chris Pratt", "Bryce Dallas Howard", "Rafe Spall" ],
+            type: "movie"
+          },
+          {
+            title: "Tag",
+            genres: [ "Comedy", "Action" ],
+            runtime: 105,
+            rated: "R",
+            year: 2018,
+            directors: [ "Jeff Tomsic" ],
+            cast: [ "Annabelle Wallis", "Jeremy Renner", "Jon Hamm" ],
+            type: "movie"
+          }
+      ])
 
-.. code-block:: javascript
- 
-   db.movies.find( {} )
+   :method:`~db.collection.insertMany()` returns a document that
+   includes the newly inserted documents' ``_id`` field values.
+
+   To :ref:`read documents in the collection <mongosh-read>`:
+
+   .. code-block:: javascript
+    
+      db.movies.find( {} )
 
 Insert Behavior
 ---------------

--- a/source/crud/insert.txt
+++ b/source/crud/insert.txt
@@ -1,0 +1,97 @@
+.. _mongosh-insert:
+
+================
+Insert Documents
+================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+.. include:: /includes/admonitions/fact-mdb-shell-beta.rst
+
+The MongoDB shell provides the following methods to insert documents
+into a collection:
+
+- To insert a single document, use :method:`db.collection.insertOne()`.
+
+- To insert multiple documents, use
+  :method:`db.collection.insertMany()`.
+
+Insert a Single Document
+------------------------
+
+:method:`db.collection.insertOne()` inserts a *single*
+:ref:`document<bson-document-format>` into a collection.
+
+The following example inserts a new document into the ``inventory``
+collection. If the document does not specify an ``_id`` field, MongoDB
+adds the ``_id`` field with an ObjectId value to the new document. See
+:ref:`write-op-insert-behavior`.
+
+.. code-block:: javascript
+
+   db.inventory.insertOne(
+      { item: "canvas", qty: 100, tags: ["cotton"], size: { h: 28, w: 35.5, uom: "cm" } }
+   )
+
+:method:`~db.collection.insertOne()` returns a document that
+includes the newly inserted document's ``_id`` field value.
+
+To retrieve the inserted document,
+:ref:`read the collection <mongosh-read>`:
+
+.. code-block:: javascript
+
+   db.inventory.find( { item: "canvas" } )
+
+Insert Multiple Documents
+-------------------------
+
+:method:`db.collection.insertMany()` can insert *multiple*
+:ref:`documents <bson-document-format>` into a collection. Pass an array
+of documents to the method.
+
+The following example inserts three new documents into the ``inventory``
+collection. If the documents do not specify an ``_id`` field, MongoDB
+adds the ``_id`` field with an ObjectId value to each document. See
+:ref:`write-op-insert-behavior`.
+
+.. code-block:: javascript
+
+   db.inventory.insertMany([
+      { item: "journal", qty: 25, tags: ["blank", "red"], size: { h: 14, w: 21, uom: "cm" } },
+      { item: "mat", qty: 85, tags: ["gray"], size: { h: 27.9, w: 35.5, uom: "cm" } },
+      { item: "mousepad", qty: 25, tags: ["gel", "blue"], size: { h: 19, w: 22.85, uom: "cm" } }
+   ])
+
+:method:`~db.collection.insertMany()` returns a document that includes
+the newly inserted documents ``_id`` field values.
+
+To retrieve the inserted documents,
+:ref:`read the collection <mongosh-read>`:
+
+.. code-block:: javascript
+ 
+   db.inventory.find( {} )
+
+Insert Behavior
+---------------
+
+To learn more about the specific behavior of inserting documents,
+see :ref:`write-op-insert-behavior`.
+
+Learn More
+----------
+
+- To see more examples of inserting documents into a collection, see
+  the :method:`~db.collection.insertOne()` and
+  :method:`db.collection.insertMany()` method pages.
+
+- To see all available methods to insert documents into a collection,
+  see :manual:`Additional Methods for Inserts
+  </reference/insert-methods/#additional-inserts>`

--- a/source/crud/read.txt
+++ b/source/crud/read.txt
@@ -1,0 +1,166 @@
+.. _mongosh-read:
+
+===============
+Query Documents
+===============
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+.. include:: /includes/admonitions/fact-mdb-shell-beta.rst
+
+Use the :method:`db.collection.find()` method in the |mdb-shell|
+to query documents in a collection.
+
+.. include:: /includes/fact-sample-data-examples.rst
+
+.. TODO: Make a callout here to the Connect to an Atlas Cluster section
+   in the connection docs
+
+Select All Documents in a Collection
+------------------------------------
+
+To select all documents in the collection, pass an empty document as the
+query filter parameter to the find method. The query filter parameter
+determines the select criteria.
+
+.. example::
+
+   To return all documents from the ``sample_mflix.movies`` collection:
+
+   .. code-block:: javascript
+
+      use sample_mflix
+
+      db.movies.find()
+
+   This operation is equivalent to the following SQL statement:
+
+   .. code-block:: sql
+      :copyable: false
+
+      SELECT * FROM movies
+
+Specify Equality Condition
+--------------------------
+
+To select documents which match an equality condition, specify
+the condition as a ``<field>:<value>`` pair in the
+:manual:`query filter document </document/#query-filter-documents>`.
+
+.. example::
+
+   To return all movies where the ``title`` equals ``Titanic`` from the
+   ``sample_mflix.movies`` collection:
+
+   .. code-block:: javascript
+
+      use sample_mflix
+
+      db.movies.find( { "title": "Titanic" } )
+
+   This operation corresponds to the following SQL statement:
+
+   .. code-block:: sql
+      :copyable: false
+
+      SELECT * FROM movies WHERE title = "Titanic"
+
+Specify Conditions Using Query Operators
+----------------------------------------
+
+Use :manual:`query operators
+</reference/operator/query/#query-selectors>` in a
+:manual:`query filter document </core/document/#document-query-filter>`
+to perform more complex comparisons and evaluations. Query operators
+in a query filter document have the following form:
+
+.. code-block:: javascript
+
+   { <field1>: { <operator1>: <value1> }, ... }
+
+.. example::
+
+   To return all movies from the ``sample_mflix.movies`` collection
+   which are either rated ``PG`` or ``PG-13``:
+
+   .. code-block:: javascript
+
+      use sample_mflix
+
+      db.movies.find( { rated: { $in: [ "PG", "PG-13" ] } } )
+
+   This operation corresponds to the following SQL statement:
+
+   .. code-block:: sql
+      :copyable: false
+
+      SELECT * FROM movies WHERE rated in ("PG", "PG-13")
+
+.. note::
+
+   Although you can express this query using the :query:`$or` operator,
+   use the :query:`$in` operator rather than the :query:`$or`
+   operator when performing equality checks on the same field.
+
+Specify Logical Operators (``AND`` / ``OR``)
+--------------------------------------------
+
+A compound query can specify conditions for more than one field in the
+collection's documents. Implicitly, a logical ``AND`` conjunction
+connects the clauses of a compound query so that the query selects the
+documents in the collection that match all the conditions.
+
+.. example::
+
+   To return movies which were released in Mexico **and** have an IMDB
+   rating of at least 7:
+
+   .. code-block:: javascript
+
+      use sample_mflix
+
+      db.movies.find( { countries: "Mexico", "imdb.rating": { $gte: 7 } } )
+
+Use the :query:`$or` operator to specify a compound query that joins
+each clause with a logical ``OR`` conjunction so that the query selects
+the documents in the collection that match at least one condition.
+
+.. example::
+
+   To return movies from the ``sample_mflix.movies`` collection which
+   were released in 2010 **and** *either* won at least 5 awards or
+   have a ``genre`` of ``Drama``:
+
+   .. code-block:: javascript
+
+      use sample_mflix
+
+      db.movies.find( {
+           year: 2010,
+           $or: [ { "awards.wins": { $gte: 5 } }, { genres: "Drama" } ]
+      } )
+
+Additional Query Tutorials
+--------------------------
+
+For additional query examples, see:
+
+- :manual:`Query Embedded Documents
+  </tutorial/query-embedded-documents>`
+
+- :manual:`Query an Array </tutorial/query-arrays>`
+
+- :manual:`Query an Array of Embedded Documents 
+  </tutorial/query-array-of-documents>`
+
+- :manual:`Project Fields to Return from Query
+  </tutorial/project-fields-from-query-results>`
+
+- :manual:`Query for Null or Missing Fields
+  </tutorial/query-for-null-fields>`

--- a/source/crud/read.txt
+++ b/source/crud/read.txt
@@ -22,10 +22,10 @@ to query documents in a collection.
 .. TODO: Make a callout here to the Connect to an Atlas Cluster section
    in the connection docs
 
-Select All Documents in a Collection
-------------------------------------
+Read All Documents in a Collection
+----------------------------------
 
-To select all documents in the collection, pass an empty document as the
+To read all documents in the collection, pass an empty document as the
 query filter parameter to the find method. The query filter parameter
 determines the select criteria.
 
@@ -145,6 +145,12 @@ the documents in the collection that match at least one condition.
            year: 2010,
            $or: [ { "awards.wins": { $gte: 5 } }, { genres: "Drama" } ]
       } )
+
+Read Behavior
+-------------
+
+To learn more about the specific behavior of reading documents,
+see :manual:`Behavior </tutorial/query-documents/#behavior>`.
 
 Additional Query Tutorials
 --------------------------

--- a/source/crud/update.txt
+++ b/source/crud/update.txt
@@ -1,0 +1,153 @@
+.. _mongosh-update:
+
+================
+Update Documents
+================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+.. include:: /includes/admonitions/fact-mdb-shell-beta.rst
+
+The MongoDB shell provides the following methods to update documents in
+a collection:
+
+- To update a single document, use
+  :method:`db.collection.updateOne(\<filter\>, \<update\>, \<options\>)
+  <db.collection.updateOne>`.
+
+- To update multiple documents, use
+  :method:`db.collection.updateMany(\<filter\>, \<update\>, \<options\>)
+  <db.collection.updateMany>`.
+
+- To replace a document, use
+  :method:`db.collection.replaceOne(\<filter\>, \<update\>, \<options\>)
+  <db.collection.replaceOne>`.
+
+.. include:: /includes/fact-sample-data-examples.rst
+
+Update Operator Syntax
+----------------------
+
+To update a document, MongoDB provides
+:manual:`update operators </reference/operator/update>`, such
+as :update:`$set`, to modify field values.
+
+To use the update operators, pass to the update methods an
+update document of the form:
+
+.. code-block:: javascript
+
+   {
+     <update operator>: { <field1>: <value1>, ... },
+     <update operator>: { <field2>: <value2>, ... },
+     ...
+   }
+
+Some update operators, such as :update:`$set`, create the field if
+the field does not exist. See the individual
+:manual:`update operator </reference/operator/update>` reference for
+details.
+
+Update a Single Document
+------------------------
+
+The following example uses the :method:`db.collection.updateOne()`
+method on the ``sample_mflix.movies`` collection to update the *first*
+document where ``title`` equals ``"Titanic"``:
+
+.. code-block::
+
+   use sample_mflix
+
+   db.movies.updateOne( { title: "Titanic" },
+   {
+     $set: { countries: [ "USA", "Canada" ] },
+     $currentDate: { lastUpdated: true }
+   }
+
+The update operation:
+
+- uses the :update:`$set` operator to update the value of the
+  ``countries`` array to ``[ "USA", "Canada" ]``,
+
+- uses the :update:`$currentDate` operator to update the value
+  of the ``lastUpdated`` field to the current date. If
+  ``lastUpdated`` field does not exist,
+  :update:`$currentDate` will create the field. See
+  :update:`$currentDate` for details.
+
+Update Multiple Documents
+-------------------------
+
+The following example uses the :method:`db.collection.updateMany()`
+method on the ``sample_airbnb.listingsAndReviews`` collection to update
+all documents where ``security_deposit`` is less than ``100``:
+
+.. code-block:: javascript
+
+   use sample_airbnb
+
+   db.listingsAndReviews.updateMany(
+     { security_deposit: { $lt: 100 } },
+     {
+       $set: { security_deposit: 100, minimum_nights: 1 }
+     }
+   )
+
+The update operation uses the :update:`$set` operator to update the
+value of the ``security_deposit`` field to ``100`` and the value of the
+``minimum_nights`` field to ``1``.
+
+Replace a Document
+------------------
+
+To replace the entire content of a document except for the ``_id``
+field, pass an entirely new document as the second argument to
+:method:`db.collection.replaceOne()`.
+
+When replacing a document, the replacement document must contain only
+field/value pairs. Do not include :manual:`update operators
+</reference/operator/update>` expressions.
+
+The replacement document can have different fields from the original
+document. In the replacement document, you can omit the ``_id`` field
+since the ``_id`` field is immutable; however, if you do include the
+``_id`` field, it must have the same value as the current value.
+
+The following example replaces the *first* document from the
+``sample_analytics.accounts`` collection where ``account_id: 371138``:
+
+.. code-block:: javascript
+
+   db.accounts.replaceOne(
+     { account_id: 371138 },
+     { account_id: 893421, limit: 5000, products: [ "Investment", "Brokerage" ] }
+   )
+
+Run the following command to read your updated document:
+
+.. code-block:: javascript
+
+   db.accounts.findOne( { account_id: 371138 } )
+
+Update Behavior
+---------------
+
+To learn more about the specific behavior of updating documents,
+see :manual:`Behavior </tutorial/update-documents/#behavior>`.
+
+Learn More
+----------
+
+- To learn how to update documents using an aggregation pipeline, see
+  :manual:`Updates with Aggregation Pipeline
+  </tutorial/update-documents-with-aggregation-pipeline/>`.
+
+- To see all available methods to update documents, see
+  :manual:`Update Methods </reference/update-methods>`.

--- a/source/crud/update.txt
+++ b/source/crud/update.txt
@@ -62,22 +62,25 @@ document that matches a specified filter.
 .. example::
 
    To update the *first* document in the ``sample_mflix.movies``
-   collection where ``title`` equals ``"Titanic"``:
+   collection where ``title`` equals ``"Tag"``:
 
    .. code-block::
 
       use sample_mflix
 
-      db.movies.updateOne( { title: "Titanic" },
+      db.movies.updateOne( { title: "Tag" },
       {
-        $set: { countries: [ "USA", "Canada" ] },
-        $currentDate: { lastUpdated: true }
-      }
+        $set: {
+          plot: "One month every year, five highly competitive friends
+                 hit the ground running for a no-holds-barred game of tag"
+        }
+        { $currentDate: { lastUpdated: true } }
+      })
 
    The update operation:
 
    - Uses the :update:`$set` operator to update the value of the
-     ``countries`` array to ``[ "USA", "Canada" ]``.
+     ``plot`` field for the movie ``Tag``.
 
    - Uses the :update:`$currentDate` operator to update the value
      of the ``lastUpdated`` field to the current date. If

--- a/source/crud/update.txt
+++ b/source/crud/update.txt
@@ -18,16 +18,13 @@ The MongoDB shell provides the following methods to update documents in
 a collection:
 
 - To update a single document, use
-  :method:`db.collection.updateOne(\<filter\>, \<update\>, \<options\>)
-  <db.collection.updateOne>`.
+  :method:`db.collection.updateOne()`.
 
 - To update multiple documents, use
-  :method:`db.collection.updateMany(\<filter\>, \<update\>, \<options\>)
-  <db.collection.updateMany>`.
+  :method:`db.collection.updateMany()`.
 
 - To replace a document, use
-  :method:`db.collection.replaceOne(\<filter\>, \<update\>, \<options\>)
-  <db.collection.replaceOne>`.
+  :method:`db.collection.replaceOne()`.
 
 .. include:: /includes/fact-sample-data-examples.rst
 
@@ -57,52 +54,62 @@ details.
 Update a Single Document
 ------------------------
 
-The following example uses the :method:`db.collection.updateOne()`
-method on the ``sample_mflix.movies`` collection to update the *first*
-document where ``title`` equals ``"Titanic"``:
+Use the :method:`db.collection.updateOne()` method to update the *first*
+document that matches a specified filter.
 
-.. code-block::
+.. include:: /includes/admonitions/note-natural-sort-order.rst
 
-   use sample_mflix
+.. example::
 
-   db.movies.updateOne( { title: "Titanic" },
-   {
-     $set: { countries: [ "USA", "Canada" ] },
-     $currentDate: { lastUpdated: true }
-   }
+   To update the *first* document in the ``sample_mflix.movies``
+   collection where ``title`` equals ``"Titanic"``:
 
-The update operation:
+   .. code-block::
 
-- Uses the :update:`$set` operator to update the value of the
-  ``countries`` array to ``[ "USA", "Canada" ]``.
+      use sample_mflix
 
-- Uses the :update:`$currentDate` operator to update the value
-  of the ``lastUpdated`` field to the current date. If
-  ``lastUpdated`` field does not exist,
-  :update:`$currentDate` will create the field. See
-  :update:`$currentDate` for details.
+      db.movies.updateOne( { title: "Titanic" },
+      {
+        $set: { countries: [ "USA", "Canada" ] },
+        $currentDate: { lastUpdated: true }
+      }
+
+   The update operation:
+
+   - Uses the :update:`$set` operator to update the value of the
+     ``countries`` array to ``[ "USA", "Canada" ]``.
+
+   - Uses the :update:`$currentDate` operator to update the value
+     of the ``lastUpdated`` field to the current date. If
+     ``lastUpdated`` field does not exist,
+     :update:`$currentDate` will create the field. See
+     :update:`$currentDate` for details.
 
 Update Multiple Documents
 -------------------------
 
-The following example uses the :method:`db.collection.updateMany()`
-method on the ``sample_airbnb.listingsAndReviews`` collection to update
-all documents where ``security_deposit`` is less than ``100``:
+Use the :method:`db.collection.updateMany()` to update all documents
+that match a specified filter.
 
-.. code-block:: javascript
+.. example::
 
-   use sample_airbnb
+   To update all documents in the ``sample_airbnb.listingsAndReviews``
+   collection to update where ``security_deposit`` is less than ``100``:
 
-   db.listingsAndReviews.updateMany(
-     { security_deposit: { $lt: 100 } },
-     {
-       $set: { security_deposit: 100, minimum_nights: 1 }
-     }
-   )
+   .. code-block:: javascript
 
-The update operation uses the :update:`$set` operator to update the
-value of the ``security_deposit`` field to ``100`` and the value of the
-``minimum_nights`` field to ``1``.
+      use sample_airbnb
+
+      db.listingsAndReviews.updateMany(
+        { security_deposit: { $lt: 100 } },
+        {
+          $set: { security_deposit: 100, minimum_nights: 1 }
+        }
+      )
+
+   The update operation uses the :update:`$set` operator to update the
+   value of the ``security_deposit`` field to ``100`` and the value of
+   the ``minimum_nights`` field to ``1``.
 
 Replace a Document
 ------------------
@@ -120,21 +127,24 @@ document. In the replacement document, you can omit the ``_id`` field
 since the ``_id`` field is immutable; however, if you do include the
 ``_id`` field, it must have the same value as the current value.
 
-The following example replaces the *first* document from the
-``sample_analytics.accounts`` collection where ``account_id: 371138``:
+.. example::
 
-.. code-block:: javascript
+   To replace the *first* document from the
+   ``sample_analytics.accounts`` collection where
+   ``account_id: 371138``:
 
-   db.accounts.replaceOne(
-     { account_id: 371138 },
-     { account_id: 893421, limit: 5000, products: [ "Investment", "Brokerage" ] }
-   )
+   .. code-block:: javascript
 
-Run the following command to read your updated document:
+      db.accounts.replaceOne(
+        { account_id: 371138 },
+        { account_id: 893421, limit: 5000, products: [ "Investment", "Brokerage" ] }
+      )
 
-.. code-block:: javascript
+   Run the following command to read your updated document:
 
-   db.accounts.findOne( { account_id: 371138 } )
+   .. code-block:: javascript
+
+      db.accounts.findOne( { account_id: 893421 } )
 
 Update Behavior
 ---------------

--- a/source/crud/update.txt
+++ b/source/crud/update.txt
@@ -73,10 +73,10 @@ document where ``title`` equals ``"Titanic"``:
 
 The update operation:
 
-- uses the :update:`$set` operator to update the value of the
-  ``countries`` array to ``[ "USA", "Canada" ]``,
+- Uses the :update:`$set` operator to update the value of the
+  ``countries`` array to ``[ "USA", "Canada" ]``.
 
-- uses the :update:`$currentDate` operator to update the value
+- Uses the :update:`$currentDate` operator to update the value
   of the ``lastUpdated`` field to the current date. If
   ``lastUpdated`` field does not exist,
   :update:`$currentDate` will create the field. See

--- a/source/includes/admonitions/note-natural-sort-order.rst
+++ b/source/includes/admonitions/note-natural-sort-order.rst
@@ -1,0 +1,6 @@
+.. note::
+
+   MongoDB preserves a natural sort order for documents. This
+   ordering is an internal implementation feature, and you should not
+   rely on any particular structure within it. To learn more, see
+   :term:`natural order`.

--- a/source/includes/fact-sample-data-examples.rst
+++ b/source/includes/fact-sample-data-examples.rst
@@ -1,0 +1,8 @@
+The examples on this page reference the |service|
+:atlas:`sample dataset </sample-data/>`. You can create a free |service|
+cluster and populate that cluster with sample data to follow along with
+these examples. To learn more, see
+:atlas:`Get Started with Atlas </getting-started/>`.
+
+Alternatively, follow the :ref:`insert documents <mongosh-insert>`
+tutorial to learn how to populate a collection with data.

--- a/source/includes/fact-sample-data-examples.rst
+++ b/source/includes/fact-sample-data-examples.rst
@@ -3,6 +3,3 @@ The examples on this page reference the |service|
 cluster and populate that cluster with sample data to follow along with
 these examples. To learn more, see
 :atlas:`Get Started with Atlas </getting-started/>`.
-
-Alternatively, follow the :ref:`insert documents <mongosh-insert>`
-tutorial to learn how to populate a collection with data.

--- a/source/reference/methods.txt
+++ b/source/reference/methods.txt
@@ -4,6 +4,8 @@
 MongoDB Shell Methods
 =====================
 
+.. default-domain:: mongodb
+
 .. contents:: On this page
    :local:
    :backlinks: none


### PR DESCRIPTION
Staged: [Perform CRUD Operations](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker/DOCSP-10504/crud) plus sub-pages.

Questions for review

- What do you think about the flow here where we highlight the Atlas sample data? I wanted to insert data into a fresh collection, so they at least have something to work with if they don't want to spin up an Atlas cluster.

- There is a little bit of inconsistency between using `example` blocks and going with "For example..." prose. Lmk if you have a preference or if you think we should standardize more than what's done here.