### PR TITLE
(DOCSP-10539): Install tweaks for Homebrew

### DIFF
--- a/source/includes/steps-install-shell-base.yaml
+++ b/source/includes/steps-install-shell-base.yaml
@@ -34,7 +34,7 @@ content: |
 
    .. code-block:: sh
 
-     chmod +x /path/to/mongosh
+      chmod +x /path/to/mongosh
 ---
 title: "Add the MongoDB Shell binary to your ``PATH`` environment
    variable."

--- a/source/includes/steps-install-shell-base.yaml
+++ b/source/includes/steps-install-shell-base.yaml
@@ -23,12 +23,18 @@ ref: extract-archive
 level: 4
 content: |
    
-   .. code-block::
+   .. code-block:: sh
 
       tar -zxvf path/to/archive
 
-   Skip this step if your web browser automatically unzips the file as
-   part of the download.
+   If your web browser automatically extracts the archive as
+   part of the download or you extract the archive without the
+   ``tar`` command, you may need to run the following command to
+   make ``mongosh`` executable:
+
+   .. code-block:: sh
+
+     chmod +x /path/to/mongosh
 ---
 title: "Add the MongoDB Shell binary to your ``PATH`` environment
    variable."

--- a/source/includes/steps-install-shell-macos-homebrew.yaml
+++ b/source/includes/steps-install-shell-macos-homebrew.yaml
@@ -4,12 +4,8 @@ ref: install-homebrew
 level: 4
 content: |
 
-   Run the following command to install the
-   `Homebrew <https://brew.sh/>`__ package manager:
-
-   .. code-block:: sh
-  
-      /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+   Refer to the `Homebrew <https://brew.sh/>`__ website
+   for instructions to install Homebrew on macOS.
 ---
 title: "Tap the MongoDB Homebrew Tap."
 ref: tab-mongodb

--- a/source/includes/steps-install-shell-macos-homebrew.yaml
+++ b/source/includes/steps-install-shell-macos-homebrew.yaml
@@ -1,0 +1,37 @@
+---
+title: "Install Homebrew."
+ref: install-homebrew
+level: 4
+content: |
+
+   Run the following command to install the
+   `Homebrew <https://brew.sh/>`__ package manager:
+
+   .. code-block:: sh
+  
+      /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
+---
+title: "Tap the MongoDB Homebrew Tap."
+ref: tab-mongodb
+level: 4
+content: |
+
+   Issue the following command from the terminal to tap the official
+   `MongoDB Homebrew Tap <https://github.com/mongodb/homebrew-brew>`__:
+
+   .. code-block:: sh
+
+      brew tap mongodb/brew
+---
+title: "Install the ``mongosh`` package."
+ref: install-mongosh-package
+level: 4
+content: |
+
+   Issue the following command from the terminal to install the
+   ``mongosh`` package:
+
+   .. code-block:: sh
+
+      brew install mongosh
+...

--- a/source/includes/steps-install-shell-macos-homebrew.yaml
+++ b/source/includes/steps-install-shell-macos-homebrew.yaml
@@ -5,7 +5,7 @@ level: 4
 content: |
 
    Refer to the `Homebrew <https://brew.sh/>`__ website
-   for instructions to install Homebrew on macOS.
+   for the steps to install Homebrew on macOS.
 ---
 title: "Tap the MongoDB Homebrew Tap."
 ref: tab-mongodb

--- a/source/includes/steps-install-shell-macos.yaml
+++ b/source/includes/steps-install-shell-macos.yaml
@@ -30,10 +30,14 @@ level: 4
 content: |
    macOS may prevent ``mongosh`` from running after installation. If
    you receive a security error when starting ``mongosh`` indicating
-   that the developer could not be identified or verified, run
-   the following command:
+   that the developer could not be identified or verified, perform
+   the following actions:
 
-   .. code-block:: sh
+   a. Open *System Preferences*.
+   
+   #. Select the *Security and Privacy* pane.
 
-      xattr -r -d com.apple.quarantine /path/to/mongosh
+   #. Under the *General* tab, click the button to the right of the
+      message about ``mongod``, labelled either :guilabel:`Open Anyway`
+      or :guilabel:`Allow Anyway` depending on your version of macOS.
 ...

--- a/source/includes/steps-install-shell-macos.yaml
+++ b/source/includes/steps-install-shell-macos.yaml
@@ -38,6 +38,6 @@ content: |
    #. Select the *Security and Privacy* pane.
 
    #. Under the *General* tab, click the button to the right of the
-      message about ``mongod``, labelled either :guilabel:`Open Anyway`
+      message about ``mongosh``, labelled either :guilabel:`Open Anyway`
       or :guilabel:`Allow Anyway` depending on your version of macOS.
 ...

--- a/source/includes/steps-install-shell-macos.yaml
+++ b/source/includes/steps-install-shell-macos.yaml
@@ -23,5 +23,17 @@ source:
   file: steps-install-shell-base.yaml
   ref: add-shell-to-path
 ref: add-shell-to-path-macos
+---
+title: "Allow macOS to Run ``mongosh``."
+ref: remove-quarantine-macos
+level: 4
+content: |
+   macOS may prevent ``mongosh`` from running after installation. If
+   you receive a security error when starting ``mongosh`` indicating
+   that the developer could not be identified or verified, run
+   the following command:
 
+   .. code-block:: sh
+
+      xattr -r -d com.apple.quarantine /path/to/mongosh
 ...

--- a/source/index.txt
+++ b/source/index.txt
@@ -24,37 +24,8 @@ download center.
 Download and Install the |mdb-shell|
 ------------------------------------
 
-Prerequisites
-~~~~~~~~~~~~~
-
-To use the |mdb-shell|, you must have a MongoDB deployment to connect
-to. 
-
-- For a free cloud-hosted deployment, you can use
-  `MongoDB Atlas <https://www.mongodb.com/cloud/atlas?tck=docs_vsce>`__.
-
-- To learn how to run a local MongoDB deployment, see
-  :manual:`Install MongoDB </installation/>`.
-
-Procedure
-~~~~~~~~~
-
-.. tabs-platforms::
-
-   .. tab::
-      :tabid: windows
-
-      .. include:: /includes/steps/install-shell-windows.rst
-
-   .. tab::
-      :tabid: macOS
-
-      .. include:: /includes/steps/install-shell-macos.rst
-
-   .. tab::
-      :tabid: linux
-      
-      .. include:: /includes/steps/install-shell-generic-linux.rst
+To learn how to download and install the |mdb-shell|, see
+:ref:`mdb-shell-install`.
 
 Connect to a MongoDB Deployment
 -------------------------------
@@ -138,7 +109,8 @@ Learn More
 
    .. toctree::
       :titlesonly:
-
+      
+      /install
       /connect
       /crud
       /run-agg-pipelines

--- a/source/install.txt
+++ b/source/install.txt
@@ -50,9 +50,13 @@ Procedure
          minimum `node.JS <https://nodejs.org/en/download/>`__ version
          of ``12.0.0``.
 
-      Homebrew is the recommended installation method for ``mongosh``
-      on macOS. To learn how to manually install ``mongosh`` from an
-      archive, see :ref:`macos-install-archive`.
+         To view the complete list of system requirements for Homebrew,
+         see the
+         `Homebrew Website <https://docs.brew.sh/Installation>`__.
+
+      The Homebrew package manager is the recommended installation
+      method for ``mongosh`` on macOS. To learn how to manually install
+      ``mongosh`` from an archive, see :ref:`macos-install-archive`.
 
       To install ``mongosh`` with Homebrew:
 

--- a/source/install.txt
+++ b/source/install.txt
@@ -1,0 +1,80 @@
+.. _mdb-shell-install:
+
+=======================
+Install the |mdb-shell|
+=======================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+.. include:: /includes/admonitions/fact-mdb-shell-beta.rst
+
+Prerequisites
+-------------
+
+To use the |mdb-shell|, you must have a MongoDB deployment to connect
+to. 
+
+- For a free cloud-hosted deployment, you can use
+  `MongoDB Atlas <https://www.mongodb.com/cloud/atlas?tck=docs_vsce>`__.
+
+- To learn how to run a local MongoDB deployment, see
+  :manual:`Install MongoDB </installation/>`.
+
+Procedure
+---------
+
+.. tabs-platforms::
+
+   .. tab::
+      :tabid: windows
+
+      .. include:: /includes/steps/install-shell-windows.rst
+
+   .. tab::
+      :tabid: macOS
+
+      .. _macos-install-homebrew:
+
+      Install with Homebrew
+      ~~~~~~~~~~~~~~~~~~~~~
+
+      .. important::
+
+         To install ``mongosh`` with Homebrew on macOS, you must have a
+         minimum `node.JS <https://nodejs.org/en/download/>`__ version
+         of ``12.0.0``.
+
+      Homebrew is the recommended installation method for ``mongosh``
+      on macOS. To learn how to manually install ``mongosh`` from an
+      archive, see :ref:`macos-install-archive`.
+
+      To install ``mongosh`` with Homebrew:
+
+      .. include:: /includes/steps/install-shell-macos-homebrew.rst
+
+      .. _macos-install-archive:
+
+      Install from Tarball
+      ~~~~~~~~~~~~~~~~~~~~
+
+      To manually install ``mongosh`` using a downloaded ``.tgz``
+      tarball:
+
+      .. include:: /includes/steps/install-shell-macos.rst
+
+   .. tab::
+      :tabid: linux
+      
+      .. include:: /includes/steps/install-shell-generic-linux.rst
+
+Next Steps
+----------
+
+Once you successfully install ``mongosh``, learn how to
+:ref:`connect to your MongoDB deployment <mdb-shell-connect>`.


### PR DESCRIPTION
Scope of Changes:

- Moved Install Instructions to their own page. Motivation: This section was getting long and the home page was kind of losing its meaning. Instead, I'm trying to keep the scope home page to high-level, important features of the MongoDB Shell. This also provides symmetry with the rest of our docs where most often Install gets its own page.

- Added instructions for install with Homebrew.

- Tweaked instructions for package install. Specifically:

  - Make mongosh executable
  - Remove mongosh from quarantine

- Added a "Next Steps" section pointing users to the connection page.

Staging:

[Install the MongoDB Shell](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker/DOCSP-10539/install)