### PR TITLE
(DOCSP-10666) Update mongosh connection page with --port and --host

### DIFF
--- a/source/connect.txt
+++ b/source/connect.txt
@@ -97,7 +97,7 @@ To specify a remote host and port, you can use:
 
         mongosh --host mongodb://mongodb0.example.com:28015
 
-- Command-line options ``--host`` and ``--port``.
+- The command-line options ``--host`` and ``--port``.
 
   .. example:: 
 

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -95,7 +95,7 @@ To specify a remote host and port, you can use:
 
      .. code-block:: sh
 
-        mongosh --host mongodb://mongodb0.example.com:28015
+        mongosh --host mongodb0.example.com
 
 - The command-line options ``--host`` and ``--port``.
 

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -86,7 +86,8 @@ To specify a remote host and port, you can use:
      :atlas:`Connect to a Cluster <connect-to-cluster/#use-the-connect-dialog-to-connect-to-your-cluster>`.
 
 - The command-line options ``--host`` and ``--port``. If you do not 
-  specify a port, ``mongosh`` uses the **default port** 27017.
+  include the ``--port`` option, ``mongosh`` uses the **default port** 
+  27017.
 
   .. example:: 
 

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -85,6 +85,17 @@ To specify a remote host and port, you can use:
      your connection string from the |service| UI. To learn more, see 
      :atlas:`Connect to a Cluster <connect-to-cluster/#use-the-connect-dialog-to-connect-to-your-cluster>`.
 
+- The command-line option ``--host``.
+
+  .. example:: 
+
+     To connect to a MongoDB
+     instance running on a remote host machine on port 28015:
+
+     .. code-block:: sh
+
+        mongosh --host mongodb://mongodb0.example.com:28015
+
 - Command-line options ``--host`` and ``--port``.
 
   .. example:: 
@@ -92,7 +103,7 @@ To specify a remote host and port, you can use:
      To connect to a MongoDB
      instance running on a remote host machine on port 28015:
 
-     .. code-block:: text
+     .. code-block:: sh
 
         mongosh --host mongodb://mongodb0.example.com --port 28015
 

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -85,7 +85,8 @@ To specify a remote host and port, you can use:
      your connection string from the |service| UI. To learn more, see 
      :atlas:`Connect to a Cluster <connect-to-cluster/#use-the-connect-dialog-to-connect-to-your-cluster>`.
 
-- The command-line option ``--host``.
+- The command-line option ``--host``, specifying a port in the format 
+``<host>:<port>``.
 
   .. example:: 
 

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -73,7 +73,7 @@ To specify a remote host and port, you can use:
   .. example:: 
 
      To connect to a MongoDB
-     instance running on a remote host machine on port 28015:
+     instance running on a remote host on port 28015:
 
      .. code-block:: sh
 

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -91,7 +91,7 @@ To specify a remote host and port, you can use:
   .. example:: 
 
      To connect to a MongoDB
-     instance running on a remote host machine on port 28015:
+     instance running on a remote host on port 28015:
 
      .. code-block:: sh
 

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -102,7 +102,7 @@ To specify a remote host and port, you can use:
   .. example:: 
 
      To connect to a MongoDB
-     instance running on a remote host machine on port 28015:
+     instance running on a remote host on port 28015:
 
      .. code-block:: sh
 

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -54,23 +54,35 @@ To specify a port to connect to on localhost, use the
 MongoDB Instance on a Remote Host
 ---------------------------------
 
-To specify a remote host and port, use a 
-:manual:`connection string </reference/connection-string>`.
+To specify a remote host and port, you can use:
 
-.. example:: 
+- A :manual:`connection string </reference/connection-string>`.
 
-   To connect to a MongoDB
-   instance running on a remote host machine on port 28015:
+  .. example:: 
 
-   .. code-block:: sh
+     To connect to a MongoDB
+     instance running on a remote host machine on port 28015:
 
-      mongosh "mongodb://mongodb0.example.com:28015"
+     .. code-block:: sh
 
-.. note:: Connecting to |service|
+        mongosh "mongodb://mongodb0.example.com:28015"
 
-   If your remote host is a |service-fullname| cluster, you can copy 
-   your connection string from the |service| UI. To learn more, see 
-   :atlas:`Connect to a Cluster <connect-to-cluster/#use-the-connect-dialog-to-connect-to-your-cluster>`.
+  .. note:: Connecting to |service|
+  
+     If your remote host is a |service-fullname| cluster, you can copy 
+     your connection string from the |service| UI. To learn more, see 
+     :atlas:`Connect to a Cluster <connect-to-cluster/#use-the-connect-dialog-to-connect-to-your-cluster>`.
+
+- Command line options ``--host`` and ``--port``.
+
+  .. example:: 
+
+     To connect to a MongoDB
+     instance running on a remote host machine on port 28015:
+
+     .. code-block:: sh
+
+        mongosh --host mongodb://mongodb0.example.com --port 28015
 
 Connection Options
 ------------------

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -85,8 +85,8 @@ To specify a remote host and port, you can use:
      your connection string from the |service| UI. To learn more, see 
      :atlas:`Connect to a Cluster <connect-to-cluster/#use-the-connect-dialog-to-connect-to-your-cluster>`.
 
-- The command-line option ``--host``, specifying a port in the format 
-``<host>:<port>``.
+- The command-line option ``--host``, 
+specifying a port in the format ``<host>:<port>``.
 
   .. example:: 
 

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -106,7 +106,7 @@ To specify a remote host and port, you can use:
 
      .. code-block:: sh
 
-        mongosh --host mongodb://mongodb0.example.com --port 28015
+        mongosh --host mongodb0.example.com --port 28015
 
 Connection Options
 ------------------

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -86,7 +86,7 @@ To specify a remote host and port, you can use:
      :atlas:`Connect to a Cluster <connect-to-cluster/#use-the-connect-dialog-to-connect-to-your-cluster>`.
 
 - The command-line option ``--host``, 
-specifying a port in the format ``<host>:<port>``.
+  specifying a port in the format ``<host>:<port>``.
 
   .. example:: 
 

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -85,19 +85,8 @@ To specify a remote host and port, you can use:
      your connection string from the |service| UI. To learn more, see 
      :atlas:`Connect to a Cluster <connect-to-cluster/#use-the-connect-dialog-to-connect-to-your-cluster>`.
 
-- The command-line option ``--host``, 
-  specifying a port in the format ``<host>:<port>``.
-
-  .. example:: 
-
-     To connect to a MongoDB
-     instance running on a remote host on port 28015:
-
-     .. code-block:: sh
-
-        mongosh --host mongodb0.example.com
-
-- The command-line options ``--host`` and ``--port``.
+- The command-line options ``--host`` and ``--port``. If you do not 
+  specify a port, ``mongosh`` uses the **default port** 27017.
 
   .. example:: 
 

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -34,7 +34,7 @@ This is equivalent to the following command:
 
 .. code-block:: sh
 
-   mongosh "localhost:27017"
+   mongosh "mongodb://localhost:27017"
 
 Local MongoDB Instance on a Non-Default Port
 --------------------------------------------

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -50,7 +50,7 @@ To specify a port to connect to on localhost, you can use:
   
      .. code-block:: sh
   
-        mongosh "localhost:28015"
+        mongosh "mongodb://localhost:28015"
 
 - The command-line option ``--port``.
 

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -39,17 +39,29 @@ This is equivalent to the following command:
 Local MongoDB Instance on a Non-Default Port
 --------------------------------------------
 
-To specify a port to connect to on localhost, use the 
-:manual:`connection string </reference/connection-string>` format. 
+To specify a port to connect to on localhost, you can use:
 
-.. example::
+- A :manual:`connection string </reference/connection-string>`. 
 
-   To connect to a MongoDB instance running on localhost with a 
-   non-default port 28015:
+  .. example::
+  
+     To connect to a MongoDB instance running on localhost with a 
+     non-default port 28015:
+  
+     .. code-block:: sh
+  
+        mongosh "localhost:28015"
 
-   .. code-block:: sh
+- The command-line option ``--port``.
 
-      mongosh "localhost:28015"
+  .. example:: 
+
+     To connect to a MongoDB instance running on localhost with a 
+     non-default port 28015:
+
+     .. code-block:: sh
+
+        mongosh --port 28015
 
 MongoDB Instance on a Remote Host
 ---------------------------------
@@ -73,14 +85,14 @@ To specify a remote host and port, you can use:
      your connection string from the |service| UI. To learn more, see 
      :atlas:`Connect to a Cluster <connect-to-cluster/#use-the-connect-dialog-to-connect-to-your-cluster>`.
 
-- Command line options ``--host`` and ``--port``.
+- Command-line options ``--host`` and ``--port``.
 
   .. example:: 
 
      To connect to a MongoDB
      instance running on a remote host machine on port 28015:
 
-     .. code-block:: sh
+     .. code-block:: text
 
         mongosh --host mongodb://mongodb0.example.com --port 28015
 


### PR DESCRIPTION
[JIRA](https://jira.mongodb.org/browse/DOCSP-10666)
[Staged](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker/DOCSP-10666/connect)

Broke out **Local MongoDB Instance on a Non-Default Port** and **MongoDB Instance on a Remote Host** into bulleted lists to cover --host and --port options as well.