### PR TITLE
DOP-1208: fix one :atlas: link to use doc-style links

### DIFF
--- a/source/connect.txt
+++ b/source/connect.txt
@@ -83,7 +83,7 @@ To specify a remote host and port, you can use:
   
      If your remote host is a |service-fullname| cluster, you can copy 
      your connection string from the |service| UI. To learn more, see 
-     :atlas:`Connect to a Cluster <connect-to-cluster/#use-the-connect-dialog-to-connect-to-your-cluster>`.
+     :atlas:`Connect to a Cluster </connect-to-cluster/#use-the-connect-dialog-to-connect-to-your-cluster>`.
 
 - The command-line options ``--host`` and ``--port``. If you do not 
   include the ``--port`` option, ``mongosh`` uses the **default port** 


### PR DESCRIPTION
With next week's snooty release (on the 8th or 9th), we'll be standardizing on `:doc:`-style Atlas links (i.e. including the leading `/`). This PR addresses the one `:atlas:` link in this repository that didn't already have the leading `/`.

Staging: https://docs-mongodborg-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/atlas-link/connect *note* that the link in staging is currently broken because I'm building on the production autobuilder rather than the version we'll release next week. 

Workerpool: https://workerpool-boxgs.mongodbstitch.com/pages/job.html?jobId=5eff8258a025140d8c12fd39