### PR TITLE
(DOCSP-11251): Clarify that MongoDB Shell and mongosh are synonymous

### DIFF
--- a/source/includes/admonitions/fact-mdb-shell-beta.rst
+++ b/source/includes/admonitions/fact-mdb-shell-beta.rst
@@ -1,6 +1,6 @@
 .. admonition:: Beta
    :class: note
 
-   |mdb-shell| is currently available as a **Beta** release. The
-   product, its features, and the corresponding documentation may
-   change during the Beta stage.
+   The |mdb-shell| (``mongosh``) is currently available as a **Beta**
+   release. The product, its features, and the corresponding
+   documentation may change during the Beta stage.

--- a/source/includes/steps-install-shell-base.yaml
+++ b/source/includes/steps-install-shell-base.yaml
@@ -36,7 +36,7 @@ content: |
 
       chmod +x /path/to/mongosh
 ---
-title: "Add the MongoDB Shell binary to your ``PATH`` environment
+title: "Add the ``mongosh`` binary to your ``PATH`` environment
    variable."
 ref: add-shell-to-path
 level: 4
@@ -44,7 +44,7 @@ content: |
 
    You can either:
 
-   - Copy the |mdb-shell| binary into a directory listed in your ``PATH``
+   - Copy the ``mongosh`` binary into a directory listed in your ``PATH``
      variable, such as ``/usr/local/bin`` (Update
      ``/path/to/mongosh`` with your installation directory as
      appropriate)
@@ -53,9 +53,9 @@ content: |
 
        sudo cp /path/to/mongosh /usr/local/bin/
 
-   - Create a symbolic link to the |mdb-shell| binary from a directory listed in
-     your ``PATH`` variable, such as ``/usr/local/bin`` (Update
-     ``/path/to/mongosh`` with your installation directory as
+   - Create a symbolic link to the ``mongosh`` binary from a directory
+     listed in your ``PATH`` variable, such as ``/usr/local/bin``
+     (Update ``/path/to/mongosh`` with your installation directory as
      appropriate):
 
      .. code-block:: sh

--- a/source/index.txt
+++ b/source/index.txt
@@ -14,17 +14,17 @@ MongoDB Shell
 
 .. include:: /includes/admonitions/fact-mdb-shell-beta.rst
 
-The |mdb-shell| is a fully functional JavaScript environment for
-interacting with MongoDB deployments. You can use the |mdb-shell| to
-test queries and operations directly with your database.
+The |mdb-shell|, ``mongosh``, is a fully functional JavaScript
+environment for interacting with MongoDB deployments. You can use the
+|mdb-shell| to test queries and operations directly with your database.
 
-The |mdb-shell| is available as a standalone package in the MongoDB
+``mongosh`` is available as a standalone package in the MongoDB
 download center.
 
 Download and Install the |mdb-shell|
 ------------------------------------
 
-To learn how to download and install the |mdb-shell|, see
+To learn how to download and install the ``mongosh`` binary, see
 :ref:`mdb-shell-install`.
 
 Connect to a MongoDB Deployment
@@ -78,8 +78,8 @@ you had entered into the editor.
 The |mdb-shell| versus the Legacy ``mongo`` Shell
 -------------------------------------------------
 
-The |mdb-shell| offers numerous advantages over the legacy
-:binary:`mongo <mongo>` shell, such as:
+The new MongoDB Shell, ``mongosh``, offers numerous
+advantages over the legacy :binary:`~bin.mongo` shell, such as:
 
 - Improved syntax highlighting.
 
@@ -87,12 +87,15 @@ The |mdb-shell| offers numerous advantages over the legacy
 
 - Improved logging.
 
-During the beta stage, the |mdb-shell| supports a subset of the legacy
-:binary:`mongo <mongo>` shell commands. Extending the |mdb-shell| |api|
-coverage is an ongoing effort.
+During the beta stage, ``mongosh`` supports a subset of the
+:binary:`~bin.mongo` shell methods. Achieving feature parity between
+``mongosh`` and the ``mongo`` shell is an ongoing effort.
 
-The commands that the |mdb-shell| supports use the same syntax as the
-corresponding commands in the legacy :binary:`mongo <mongo>` shell.
+To maintain backwards compatibility, the methods that ``mongosh``
+supports use the same syntax as the corresponding methods in the
+:binary:`~bin.mongo` shell. To see the complete list of methods
+supported by ``mongosh``, see
+:doc:`MongoDB Shell Methods </reference/methods>`.
 
 Learn More 
 ----------

--- a/source/install.txt
+++ b/source/install.txt
@@ -1,8 +1,8 @@
 .. _mdb-shell-install:
 
-=======================
-Install the |mdb-shell|
-=======================
+===================
+Install ``mongosh``
+===================
 
 .. default-domain:: mongodb
 


### PR DESCRIPTION
Staged: https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-11251/