### PR TITLE
(DOCSP-10991): add Mongo() and scripting docs

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -6,7 +6,6 @@ intersphinx = ["https://docs.mongodb.com/manual/objects.inv"]
 toc_landing_pages = ["/crud"]
 
 [constants]
-mdb-shell = "The MongoDB Shell"
 
 [substitutions]
 

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -209,7 +209,7 @@ Connect to a Different Deployment
 
 You can use the :method:`Mongo()` or the :manual:`connect()
 </reference/method/connect/>` methods to connect to a different MongoDB
-deployment from within the {+mdb-shell+}.
+deployment from within the |mdb-shell|.
 
 To learn how to connect to a different deployment using these methods,
 see :ref:`mdb-shell-open-new-connections-in-shell`.

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -207,8 +207,9 @@ For ``tls`` connections:
 Connect to a Different Deployment
 ---------------------------------
 
-You can use the :method:`Mongo()` or the :method:`connect()` methods to 
-connect to a different MongoDB deployment from within the {+mdb-shell+}.
+You can use the :method:`Mongo()` or the :manual:`connect()
+</reference/method/connect/>` methods to connect to a different MongoDB
+deployment from within the {+mdb-shell+}.
 
 To learn how to connect to a different deployment using these methods,
 see :ref:`mdb-shell-open-new-connections-in-shell`.

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -204,6 +204,15 @@ For ``tls`` connections:
 
         mongosh "mongodb://mongodb0.example.com:28015" --tls
 
+Connect to A Different Deployment
+---------------------------------
+
+You can use the :method:`Mongo()` or the :method:`connect()` methods to 
+connect to a different MongoDB deployment from within the {+mdb-shell+}.
+
+To learn how to connect to a different deployment from within the
+{+mdb-shell+}, see :ref:`mdb-shell-open-new-connections-in-shell`.
+
 Disconnect from a Deployment
 ----------------------------
 

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -204,14 +204,14 @@ For ``tls`` connections:
 
         mongosh "mongodb://mongodb0.example.com:28015" --tls
 
-Connect to A Different Deployment
+Connect to a Different Deployment
 ---------------------------------
 
 You can use the :method:`Mongo()` or the :method:`connect()` methods to 
 connect to a different MongoDB deployment from within the {+mdb-shell+}.
 
-To learn how to connect to a different deployment from within the
-{+mdb-shell+}, see :ref:`mdb-shell-open-new-connections-in-shell`.
+To learn how to connect to a different deployment using these methods,
+see :ref:`mdb-shell-open-new-connections-in-shell`.
 
 Disconnect from a Deployment
 ----------------------------

--- a/source/includes/admonitions/note-redact-credentials-command-history.rst
+++ b/source/includes/admonitions/note-redact-credentials-command-history.rst
@@ -1,5 +1,5 @@
 .. note::
 
-   The {+mdb-shell+} redacts credentials from the :ref:`command history
+   The |mdb-shell| redacts credentials from the :ref:`command history
    <mdb-shell-command-history>`, but does not redact credentials from 
    the :ref:`logs <mdb-shell-view-logs>`.

--- a/source/includes/admonitions/note-redact-credentials-command-history.rst
+++ b/source/includes/admonitions/note-redact-credentials-command-history.rst
@@ -1,0 +1,5 @@
+.. note::
+
+   The {+mdb-shell+} redacts credentials from the :ref:`command history
+   <mdb-shell-command-history>`, but does not redact credentials from 
+   the :ref:`logs <mdb-shell-view-logs>`.

--- a/source/includes/admonitions/note-redact-credentials-command-history.rst
+++ b/source/includes/admonitions/note-redact-credentials-command-history.rst
@@ -1,5 +1,5 @@
 .. note::
 
    The |mdb-shell| redacts credentials from the :ref:`command history
-   <mdb-shell-command-history>`, but does not redact credentials from 
-   the :ref:`logs <mdb-shell-view-logs>`.
+   <mdb-shell-command-history>` and the :ref:`logs
+   <mdb-shell-view-logs>`.

--- a/source/index.txt
+++ b/source/index.txt
@@ -103,6 +103,10 @@ Learn More
 
 - :ref:`Run Aggregation Pipelines <mdb-shell-aggregation>`
 
+- :ref:`Write Scripts <mdb-shell-write-scripts>`
+
+- :ref:`Retrieve Logs <mdb-shell-logs>`
+
 - :ref:`View Available Methods in the MongoDB Shell <mdb-shell-methods>`
 
 .. class:: hidden
@@ -114,5 +118,6 @@ Learn More
       /connect
       /crud
       /run-agg-pipelines
+      /write-scripts
       /logs
       /reference

--- a/source/logs.txt
+++ b/source/logs.txt
@@ -19,12 +19,18 @@ Retrieve MongoDB Shell Logs
 <https://github.com/pinojs/pino>`__. 
 
 You can view or tail the logs for a |mdb-shell| session based on its
-session ID. 
+session ID.
+
+.. include:: /includes/admonitions/note-redact-credentials-command-history.rst
+
+.. _mdb-shell-view-logs:
 
 View |mdb-shell| Logs
 ---------------------
 
 .. include:: /includes/steps/view-logs.rst
+
+.. _mdb-shell-command-history:
 
 View |mdb-shell| Command History
 --------------------------------

--- a/source/write-scripts.txt
+++ b/source/write-scripts.txt
@@ -1,8 +1,8 @@
 .. _mdb-shell-write-scripts:
 
-=======================================
-Write Scripts for {+mdb-shell+}
-=======================================
+=================================
+Write Scripts for the |mdb-shell|
+=================================
 
 .. default-domain:: mongodb
 
@@ -12,10 +12,10 @@ Write Scripts for {+mdb-shell+}
    :depth: 2
    :class: singlecol
 
-You can write scripts for the MongoDB Shell that manipulate data in
+You can write scripts for the |mdb-shell| that manipulate data in
 MongoDB or perform administrative operations.
 
-This tutorial introduces using the MongoDB Shell with JavaScript to
+This tutorial introduces using the |mdb-shell| with JavaScript to
 access MongoDB.
 
 .. _mdb-shell-open-new-connections-in-shell:
@@ -23,7 +23,7 @@ access MongoDB.
 Open a New Connection
 ---------------------
 
-From the MongoDB shell or from a JavaScript file, you can instantiate
+From the |mdb-shell| or from a JavaScript file, you can instantiate
 database connections using the :method:`Mongo()` method:
 
 .. code-block:: javascript
@@ -35,7 +35,7 @@ database connections using the :method:`Mongo()` method:
 
 .. note::
 
-   {+mdb-shell+} does not support the
+   The |mdb-shell| does not support the
    :manual:`ClientSideFieldLevelEncryptionOptions
    </reference/method/Mongo/#clientsidefieldlevelencryptionoptions>`
    document with the :method:`Mongo()` method.
@@ -58,7 +58,7 @@ must include the credentials in the :manual:`connection string
 MongoDB instance that is:
 
 - Running on ``localhost`` on the default port, and
-- secured using :manual:`SCRAM </core/security-scram/>`.
+- Secured using :manual:`SCRAM </core/security-scram/>`.
 
 .. code-block:: javascript
 
@@ -93,7 +93,7 @@ The following example:
 Execute a JavaScript File
 -------------------------
 
-You can execute a ``.js`` file from within the MongoDB shell
+You can execute a ``.js`` file from within the |mdb-shell|
 using the ``.load`` command. The following command loads and executes
 the ``myjstest.js`` file:
 
@@ -101,12 +101,10 @@ the ``myjstest.js`` file:
 
    .load myjstest.js
 
-
-
 The ``.load`` command accepts relative and absolute paths. If the
-current working directory of the MongoDB shell is ``/data/db``,
+current working directory of the |mdb-shell| is ``/data/db``,
 and ``myjstest.js`` resides in the ``/data/db/scripts`` directory, then
-the following calls within the MongoDB shell are equivalent: 
+the following calls within the |mdb-shell| are equivalent: 
 
 .. code-block:: javascript
    :copyable: false
@@ -118,4 +116,4 @@ the following calls within the MongoDB shell are equivalent:
 
    There is no search path for the ``.load`` command. If the desired
    script is not in the current working directory or the full specified
-   path, the MongoDB shell cannot access the file.
+   path, the |mdb-shell| cannot access the file.

--- a/source/write-scripts.txt
+++ b/source/write-scripts.txt
@@ -1,7 +1,7 @@
 .. _mdb-shell-write-scripts:
 
 =======================================
-Write Scripts for the {+mdb-shell+}
+Write Scripts for {+mdb-shell+}
 =======================================
 
 .. default-domain:: mongodb
@@ -12,18 +12,18 @@ Write Scripts for the {+mdb-shell+}
    :depth: 2
    :class: singlecol
 
-You can write scripts for the {+mdb-shell+} that manipulate data in
+You can write scripts for the MongoDB Shell that manipulate data in
 MongoDB or perform administrative operations.
 
-This tutorial provides an introduction to writing JavaScript that uses 
-the {+mdb-shell+} shell to access MongoDB.
+This tutorial introduces using the MongoDB Shell with JavaScript to
+access MongoDB.
 
 .. _mdb-shell-open-new-connections-in-shell:
 
-Open A New Connection
+Open a New Connection
 ---------------------
 
-From the {+mdb-shell+} or from a JavaScript file, you can instantiate
+From the MongoDB shell or from a JavaScript file, you can instantiate
 database connections using the :method:`Mongo()` method:
 
 .. code-block:: javascript
@@ -35,25 +35,30 @@ database connections using the :method:`Mongo()` method:
 
 .. note::
 
-   The {+mdb-shell+} does not support the
-   ``ClientSideFieldLevelEncryptionOptions`` parameter with the
-   :method:`Mongo()` method.
+   {+mdb-shell+} does not support the
+   :manual:`ClientSideFieldLevelEncryptionOptions
+   </reference/method/Mongo/#clientsidefieldlevelencryptionoptions>`
+   document with the :method:`Mongo()` method.
 
-Consider the following example that instantiates a new connection to the
-MongoDB instance running on localhost on the default port and sets the
-global ``db`` variable to ``myDatabase`` using the :method:`getDB()`
-method:
+Consider a MongoDB instance running on localhost on the default port.
+The following example:
+
+- Instantiates a new connection to the instance, and
+- Sets the global ``db`` variable to ``myDatabase`` using the
+  :method:`getDB()` method. 
 
 .. code-block:: javascript
 
    conn = Mongo();
    db = conn.getDB("myDatabase");
 
-If connecting to a MongoDB instance that enforces access control, you
+If you connect to a MongoDB instance that enforces access control, you
 must include the credentials in the :manual:`connection string
-</reference/connection-string/>`. The following example shows you how
-to connect to a MongoDB instance running on ``localhost`` on the default
-port secured using :manual:`SCRAM </core/security-scram/>`:
+</reference/connection-string/>`. The following example connects to a
+MongoDB instance that is:
+
+- Running on ``localhost`` on the default port, and
+- secured using :manual:`SCRAM </core/security-scram/>`.
 
 .. code-block:: javascript
 
@@ -66,9 +71,11 @@ port secured using :manual:`SCRAM </core/security-scram/>`:
 .. include:: /includes/admonitions/note-redact-credentials-command-history.rst
 
 Additionally, you can use the :method:`connect()` method to connect to
-the MongoDB instance. The following example connects to the MongoDB
-instance that is running on ``localhost`` with the non-default port
-``27020`` and sets the global ``db`` variable:
+the MongoDB instance. The following example:
+
+- Connects to the MongoDB instance that is running on ``localhost`` with
+  the non-default port ``27020``, and 
+- Sets the global ``db`` variable.
 
 .. code-block:: javascript
 
@@ -85,19 +92,20 @@ instance that is running on ``localhost`` with the non-default port
 Execute a JavaScript File
 -------------------------
 
-You can execute a ``.js`` file from within the {+mdb-shell+} shell,
-using the ``.load`` command, as in the following: 
+You can execute a ``.js`` file from within the MongoDB shell
+using the ``.load`` command. The following command loads and executes
+the ``myjstest.js`` file:
 
 .. code-block:: javascript
 
    .load myjstest.js
 
-This command loads and executes the ``myjstest.js`` file.
+
 
 The ``.load`` command accepts relative and absolute paths. If the
-current working directory of the {+mdb-shell+} shell is ``/data/db``,
+current working directory of the MongoDB shell is ``/data/db``,
 and ``myjstest.js`` resides in the ``/data/db/scripts`` directory, then
-the following calls within the mongo shell would be equivalent: 
+the following calls within the MongoDB shell are equivalent: 
 
 .. code-block:: javascript
    :copyable: false
@@ -107,6 +115,6 @@ the following calls within the mongo shell would be equivalent:
 
 .. note::
 
-   There is no search path for the .load command. If the desired script
-   is not in the current working directory or the full specified path,
-   the {+mdb-shell+} will not be able to access the file.
+   There is no search path for the ``.load`` command. If the desired
+   script is not in the current working directory or the full specified
+   path, the MongoDB shell cannot access the file.

--- a/source/write-scripts.txt
+++ b/source/write-scripts.txt
@@ -41,28 +41,34 @@ database connections using the :method:`Mongo()` method:
    document with the :method:`Mongo()` method.
 
 Consider a MongoDB instance running on localhost on the default port.
-The following example:
 
-- Instantiates a new connection to the instance, and
-- Sets the global ``db`` variable to ``myDatabase`` using the
-  :method:`getDB()` method. 
+.. example::
 
-.. code-block:: javascript
+   The following example:
 
-   conn = Mongo();
-   db = conn.getDB("myDatabase");
+   - Instantiates a new connection to the instance, and
+   - Sets the global ``db`` variable to ``myDatabase`` using the
+     :method:`getDB()` method. 
+
+   .. code-block:: javascript
+
+      conn = Mongo();
+      db = conn.getDB("myDatabase");
 
 If you connect to a MongoDB instance that enforces access control, you
 must include the credentials in the :manual:`connection string
-</reference/connection-string/>`. The following example connects to a
-MongoDB instance that is:
+</reference/connection-string/>`. 
 
-- Running on ``localhost`` on the default port, and
-- Secured using :manual:`SCRAM </core/security-scram/>`.
+.. example::
 
-.. code-block:: javascript
+   The following command connects to a MongoDB instance that is:
 
-   conn = Mongo("mongodb://<username>:<password>@localhost:27017");
+   - Running on ``localhost`` on the default port, and
+   - Secured using :manual:`SCRAM </core/security-scram/>`.
+
+   .. code-block:: javascript
+
+      conn = Mongo("mongodb://<username>:<password>@localhost:27017/<authDB>");
 
 .. the manual page says to use db.auth(), which isn't implemented yet.
    this is the only way I could get it to work.
@@ -72,15 +78,18 @@ MongoDB instance that is:
 
 Additionally, you can use the :manual:`connect()
 </reference/method/connect/>` method to connect to the MongoDB instance.
-The following example:
 
-- Connects to the MongoDB instance that is running on ``localhost`` with
-  the non-default port ``27020``, and 
-- Sets the global ``db`` variable.
+.. example::
 
-.. code-block:: javascript
+   The following command:
 
-   db = connect("localhost:27020/myDatabase");
+   - Connects to the MongoDB instance that is running on ``localhost`` with
+     the non-default port ``27020``, and 
+   - Sets the global ``db`` variable.
+
+   .. code-block:: javascript
+
+      db = connect("localhost:27020/myDatabase");
 
 .. skipping the Differences Between Interactive and Scripted mongo
    section as most of the javascript equivalents to the shell helpers
@@ -90,16 +99,102 @@ The following example:
 .. also skippping --eval section as I'm having issues getting it to work
    https://docs.mongodb.com/manual/tutorial/write-scripts-for-the-mongo-shell/#eval-option
 
+Use ``require()`` to Include External Files and Modules
+-------------------------------------------------------
+
+.. important::
+
+   A complete description of Node.js, modules, and the
+   `require() <https://nodejs.org/api/modules.html#modules_require_id>`__
+   function is out of scope for this tutorial. To learn more, refer to
+   the `Node.js Documentation <https://nodejs.org/api/modules.html>`__.
+
+You can use the `require()
+<https://nodejs.org/api/modules.html#modules_require_id>`__ function in
+the |mdb-shell| to include modules which exist in separate files.
+
+Require a File
+~~~~~~~~~~~~~~
+
+You can ``require()`` JavaScript files in the |mdb-shell| without any
+additional setup or configuration.
+
+.. note::
+
+   The |mdb-shell| does not execute files imported with ``require()``.
+   The |mdb-shell| adds everything from an imported file to the current
+   execution scope.
+
+.. example::
+
+   Use one of the following commands include a file from the current
+   working directory named ``tests.js``:
+
+   .. code-block:: javascript
+
+      require('./tests.js')
+
+   .. code-block:: javascript
+      
+      var tests = require('./tests.js')
+
+Require a Native Module
+~~~~~~~~~~~~~~~~~~~~~~~
+
+You can ``require()`` native Node modules (such as
+`fs <https://nodejs.org/api/fs.html#fs_file_system>`__) in the
+|mdb-shell| without any additional setup or configuration.
+
+.. example::
+
+   Use one of the following commands to include the ``fs`` module:
+
+   .. code-block:: javascript
+
+      require('fs')
+
+   .. code-block:: javascript
+
+      var fs = require('fs');
+
+Require a Non-Native Module
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To ``require()`` non-native Node modules (such as those downloaded from
+`npm <https://www.npmjs.com/>`__) you must install the module globally
+or to the ``node_modules`` directory in your current working directory.
+
+Once you install or copy your desired package to one of the module
+directories, you can ``require()`` that package.
+
+.. example::
+
+   Use one of the following commands to include the
+   `moment <https://www.npmjs.com/package/moment>`__:
+
+   .. code-block:: javascript
+
+      require('moment')
+
+   .. code-block:: javascript
+
+      var moment = require('moment')
+
+.. _mdb-shell-execute-file:
+
 Execute a JavaScript File
 -------------------------
 
 You can execute a ``.js`` file from within the |mdb-shell|
-using the ``.load`` command. The following command loads and executes
-the ``myjstest.js`` file:
+using the ``.load`` command. 
 
-.. code-block:: javascript
+.. example::
 
-   .load myjstest.js
+   The following command loads and executes the ``myjstest.js`` file:
+
+   .. code-block:: javascript
+
+      .load myjstest.js
 
 The ``.load`` command accepts relative and absolute paths. If the
 current working directory of the |mdb-shell| is ``/data/db``,

--- a/source/write-scripts.txt
+++ b/source/write-scripts.txt
@@ -1,0 +1,112 @@
+.. _mdb-shell-write-scripts:
+
+=======================================
+Write Scripts for the {+mdb-shell+}
+=======================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+You can write scripts for the {+mdb-shell+} that manipulate data in
+MongoDB or perform administrative operations.
+
+This tutorial provides an introduction to writing JavaScript that uses 
+the {+mdb-shell+} shell to access MongoDB.
+
+.. _mdb-shell-open-new-connections-in-shell:
+
+Open A New Connection
+---------------------
+
+From the {+mdb-shell+} or from a JavaScript file, you can instantiate
+database connections using the :method:`Mongo()` method:
+
+.. code-block:: javascript
+   :copyable: false
+
+   new Mongo()
+   new Mongo(<host>)
+   new Mongo(<host:port>)
+
+.. note::
+
+   The {+mdb-shell+} does not support the
+   ``ClientSideFieldLevelEncryptionOptions`` parameter with the
+   :method:`Mongo()` method.
+
+Consider the following example that instantiates a new connection to the
+MongoDB instance running on localhost on the default port and sets the
+global ``db`` variable to ``myDatabase`` using the :method:`getDB()`
+method:
+
+.. code-block:: javascript
+
+   conn = Mongo();
+   db = conn.getDB("myDatabase");
+
+If connecting to a MongoDB instance that enforces access control, you
+must include the credentials in the :manual:`connection string
+</reference/connection-string/>`. The following example shows you how
+to connect to a MongoDB instance running on ``localhost`` on the default
+port secured using :manual:`SCRAM </core/security-scram/>`:
+
+.. code-block:: javascript
+
+   conn = Mongo("mongodb://<username>:<password>@localhost:27017");
+
+.. the manual page says to use db.auth(), which isn't implemented yet.
+   this is the only way I could get it to work.
+   https://docs.mongodb.com/manual/tutorial/write-scripts-for-the-mongo-shell/#opening-new-connections
+
+.. include:: /includes/admonitions/note-redact-credentials-command-history.rst
+
+Additionally, you can use the :method:`connect()` method to connect to
+the MongoDB instance. The following example connects to the MongoDB
+instance that is running on ``localhost`` with the non-default port
+``27020`` and sets the global ``db`` variable:
+
+.. code-block:: javascript
+
+   db = connect("localhost:27020/myDatabase");
+
+.. skipping the Differences Between Interactive and Scripted mongo
+   section as most of the javascript equivalents to the shell helpers
+   have not yet been implemented in mongosh -- revisit later
+   https://docs.mongodb.com/manual/tutorial/write-scripts-for-the-mongo-shell/#differences-between-interactive-and-scripted-mongo
+
+.. also skippping --eval section as I'm having issues getting it to work
+   https://docs.mongodb.com/manual/tutorial/write-scripts-for-the-mongo-shell/#eval-option
+
+Execute a JavaScript File
+-------------------------
+
+You can execute a ``.js`` file from within the {+mdb-shell+} shell,
+using the ``.load`` command, as in the following: 
+
+.. code-block:: javascript
+
+   .load myjstest.js
+
+This command loads and executes the ``myjstest.js`` file.
+
+The ``.load`` command accepts relative and absolute paths. If the
+current working directory of the {+mdb-shell+} shell is ``/data/db``,
+and ``myjstest.js`` resides in the ``/data/db/scripts`` directory, then
+the following calls within the mongo shell would be equivalent: 
+
+.. code-block:: javascript
+   :copyable: false
+
+   .load scripts/myjstest.js
+   .load /data/db/scripts/myjstest.js
+
+.. note::
+
+   There is no search path for the .load command. If the desired script
+   is not in the current working directory or the full specified path,
+   the {+mdb-shell+} will not be able to access the file.

--- a/source/write-scripts.txt
+++ b/source/write-scripts.txt
@@ -70,8 +70,9 @@ MongoDB instance that is:
 
 .. include:: /includes/admonitions/note-redact-credentials-command-history.rst
 
-Additionally, you can use the :method:`connect()` method to connect to
-the MongoDB instance. The following example:
+Additionally, you can use the :manual:`connect()
+</reference/method/connect/>` method to connect to the MongoDB instance.
+The following example:
 
 - Connects to the MongoDB instance that is running on ``localhost`` with
   the non-default port ``27020``, and 


### PR DESCRIPTION
[JIRA](https://jira.mongodb.org/browse/DOCSP-10991)
Stage:
- [Write Scripts for the The MongoDB Shell](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-10991/write-scripts)
- [Connect to A Different Deployment](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-10991/connect#connect-to-a-different-deployment) -- added link to new section
- [Retrieve MongoDB Shell Logs](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-10991/logs#retrieve-mongodb-shell-logs) - added note that connection credentials are redacted from the history but not the logs

few other small fixes

The scripting features were not yet documented. made sense to add those that are implemented here, too, while I was working on Mongo().