### PR TITLE
(DOCSP-11553): Add user management methods

### DIFF
--- a/source/connect.txt
+++ b/source/connect.txt
@@ -212,13 +212,13 @@ To connect to a specific database, specify a database in your
 <https://docs.mongodb.com/manual/reference/connection-string/>`__. If
 you do not specify a database in your URI path, you connect to a database named ``test``.
 
-   .. example::
+.. example::
 
-     The following connection string URI connects to database ``db1``.
+  The following connection string URI connects to database ``db1``.
 
-     .. code-block:: sh
+  .. code-block:: sh
 
-         mongosh "mongodb://localhost:27017/db1" 
+      mongosh "mongodb://localhost:27017/db1" 
 
 Connect to a Different Deployment
 ---------------------------------

--- a/source/reference/methods.txt
+++ b/source/reference/methods.txt
@@ -407,6 +407,72 @@ Database Methods
 
      - Provides access to the specified database.
 
+   * - :method:`db.logout()`
+
+     - Ends an authenticated session.
+
    * - :method:`db.runCommand()`
 
      - Runs a :manual:`database command </reference/command>`.
+
+User Management Methods
+-----------------------
+
+.. important::
+
+   The :method:`passwordPrompt()` method is currently not
+   supported in ``mongosh``. As a result, when using the following
+   methods you must specify the password as parameter:
+
+   - :method:`db.auth()`
+   - :method:`db.changeUserPassword()`
+   - :method:`db.createUser()`
+   - :method:`db.updateUser()`
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Method
+
+     - Description
+
+   * - :method:`db.auth()`
+
+     - Authenticates a user to a database.
+
+   * - :method:`db.changeUserPassword()`
+
+     - Changes an existing user’s password.
+
+   * - :method:`db.createUser()`
+
+     - Creates a new user.
+
+   * - :method:`db.dropAllUsers()`
+
+     - Deletes all users associated with a database.
+
+   * - :method:`db.dropUser()`
+
+     - Deletes a single user.
+
+   * - :method:`db.getUser()`
+
+     - Returns information about the specified user.
+
+   * - :method:`db.getUsers()`
+
+     - Returns information about all users associated with a database.
+
+   * - :method:`db.updateUser()`
+
+     - Updates a specified user's data.
+
+   * - :method:`db.grantRolesToUser()`
+
+     - Grants a role and its privileges to a user.
+
+   * - :method:`db.revokeRolesFromUser()`
+
+     - Removes a role from a user.

--- a/source/write-scripts.txt
+++ b/source/write-scripts.txt
@@ -48,7 +48,7 @@ Consider a MongoDB instance running on localhost on the default port.
 
    - Instantiates a new connection to the instance, and
    - Sets the global ``db`` variable to ``myDatabase`` using the
-     :method:`getDB()` method. 
+     :method:`Mongo.getDB()` method. 
 
    .. code-block:: javascript
 


### PR DESCRIPTION
Just to note for review, I'll also be updating the `passwordPrompt()` docs in the manual to reflect the mongosh limitation (separate ticket).

Staged: [User Management Methods](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-11553-new/reference/methods#user-management-methods)