### PR TITLE
(DOCSP-11657): Server status and info methods

### DIFF
--- a/source/reference/methods.txt
+++ b/source/reference/methods.txt
@@ -452,6 +452,66 @@ Database Methods
 
      - Runs a :manual:`database command </reference/command>`.
 
+Server Status Methods
+---------------------
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Method
+
+     - Description
+
+   * - :method:`db.hostInfo()`
+
+     - Returns a document with information about the system running
+       the MongoDB instance.
+
+   * - :method:`db.isMaster()`
+
+     - Returns a document that describes the role of the
+       :binary:`~bin.mongod` instance.
+
+       If the :binary:`~bin.mongod` is a member of a
+       replica set, then the :data:`~isMaster.ismaster` and
+       :data:`~isMaster.secondary` fields report if the instance is the
+       :term:`primary` or if it is a :term:`secondary` member of the
+       replica set.
+
+   * - :method:`db.collection.latencyStats()`
+
+     - Returns latency statistics for a specified collection.
+
+   * - :method:`db.printCollectionStats()`
+
+     - Returns statistics from every collection.
+
+   * - :method:`db.serverBuildInfo()`
+
+     - Returns a document that displays the compilation parameters for
+       the :binary:`~bin.mongod` instance.
+
+   * - :method:`db.serverCmdLineOpts()`
+
+     - Returns a document with information about the runtime options
+       used to start the MongoDB instance.
+
+   * - :method:`db.serverStatus()`
+
+     - Returns a document that provides an overview of the database
+       process.
+
+   * - :method:`db.stats()`
+
+     - Returns a document that reports on the state of the current
+       database.
+
+   * - :method:`db.version()`
+
+     - Returns the version of the :binary:`~mongod` instance.
+
+
 User Management Methods
 -----------------------
 


### PR DESCRIPTION
Tested all of these. They seem to work as expected.

Staged: [Server Status Methods](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-11657/reference/methods#server-status-methods)