### PR TITLE
(DOCSP-11658): Free monitoring methods

### DIFF
--- a/source/reference/methods.txt
+++ b/source/reference/methods.txt
@@ -452,6 +452,38 @@ Database Methods
 
      - Runs a :manual:`database command </reference/command>`.
 
+Free Monitoring Methods
+-----------------------
+
+Starting in MongoDB 4.0, MongoDB (Community Edition) offers
+:manual:`free cloud monitoring </administration/free-monitoring/>` for
+standalone and replica set deployments.
+
+.. note::
+
+   Free cloud monitoring is only available for MongoDB Community
+   Edition.
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Method
+
+     - Description
+
+   * - :method:`db.disableFreeMonitoring()`
+
+     - Disables free cloud monitoring for your deployment.
+
+   * - :method:`db.enableFreeMonitoring()`
+
+     - Enables free cloud monitoring for your deployment.
+
+   * - :method:`db.getFreeMonitoringStatus()`
+
+     - Returns the free cloud monitoring status for your deployment.
+
 Server Status Methods
 ---------------------
 


### PR DESCRIPTION
The `enableMonitoring` method is bugged. Issue raised with engineering and they should have a fix out tomorrow. Documenting these as if they all work.

Staged: [Free Monitoring Methods](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-11658/reference/methods#free-monitoring-methods)