### PR TITLE
(DOCSP-11439): BSON class help

### DIFF
--- a/source/reference/access-mdb-shell-help.txt
+++ b/source/reference/access-mdb-shell-help.txt
@@ -18,9 +18,8 @@ information.
 
 .. tip::
 
-   When accessing :ref:`database <mdb-shell-help-db>` and
-   :ref:`collection <mdb-shell-help-collection>` help in ``mongosh``,
-   you can use the ``.help()`` and ``.help`` syntaxes interchangeably.
+   When accessing help in ``mongosh``, you can use the ``.help()`` and
+   ``.help`` syntaxes interchangeably.
 
 .. _mdb-shell-help-command-line:
 
@@ -242,3 +241,53 @@ Show Additional Usage Details for a Collection Method
 
 .. didn't include the cursor details from the manual help page as
    it seems as if most of it doesn't apply for ``mongosh``
+
+BSON Class Help
+---------------
+
+``mongosh`` provides help methods for :term:`BSON <BSON>` classes. The
+help methods provide a brief overview of the BSON class and a link with
+more information.
+
+To access help for BSON classes, run ``.help()`` on either the class
+name or an instantiated instance of the class:
+
+.. code-block:: none
+
+   <BSON class>.help()
+   // or
+   <BSON class>().help()
+
+For example, to view help for the ``ObjectId`` BSON class, run one of
+the following commands:
+
+.. code-block:: javascript
+
+   ObjectId.help()
+
+.. code-block:: javascript
+
+   ObjectId().help()
+
+``mongosh`` returns the same output for both ``.help()`` methods:
+
+.. code-block:: javascript
+   :copyable: false
+
+   The ObjectId BSON Class:
+
+   For more information on usage: https://mongodb.github.io/node-mongodb-native/3.6/api/ObjectID.html
+
+``mongosh`` provides help methods for the following BSON classes:
+
+- ``BinData``
+- ``Code``
+- ``DBRef``
+- ``MinKey``
+- ``MaxKey``
+- ``NumberDecimal``
+- ``NumberInt``
+- ``NumberLong``
+- ``ObjectId``
+- ``Symbol`` *(Deprecated)*
+- ``Timestamp``


### PR DESCRIPTION
JIRA: [DOCSP-11439](https://jira.mongodb.org/browse/DOCSP-11439?)

Staged: [BSON class help](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-11439/reference/access-mdb-shell-help#bson-class-help)

Need to follow up with tech review because not all .help() methods added in [the mongosh commit](https://github.com/mongodb-js/mongosh/commit/96a730fc05e4c226e9c365e971751bf0f362af1b) seem to be working.

The following classes' help methods don't work in mongosh:

- `bsonsize`
- `MD5`
- `UUID`
- `HexData`

They return `TypeError: <className>.help is not a function`