### PR TITLE
DOCSP-11793: [MONGOSH] Support Bulk operation methods

### DIFF
--- a/source/reference/methods.txt
+++ b/source/reference/methods.txt
@@ -264,17 +264,17 @@ Bulk Operation Methods
 
    * - :method:`db.collection.initializeOrderedBulkOp()`
 
-     - Initializes and returns a new :method:`Bulk <db.collection.Bulk()>` operations
-       builder for a collection. The builder constructs an ordered list of
-       write operations that MongoDB executes in bulk.
+     - Initializes and returns a new :method:`Bulk()` operations builder
+       for a collection. The builder constructs an ordered list of write
+       operations that MongoDB executes in bulk.
 
    * - :method:`db.collection.initializeUnorderedBulkOp()`
 
-     - Initializes and returns a new :method:`db.collection.Bulk()` operations
-       builder for a collection. The builder constructs an unordered list of
-       write operations that MongoDB executes in bulk.
+     - Initializes and returns a new :method:`Bulk()` operations builder
+       for a collection. The builder constructs an unordered list of write
+       operations that MongoDB executes in bulk.
    
-   * - :method:`Bulk <db.collection.Bulk()>`
+   * - :method:`Bulk()`
 
      - Creates a bulk operations builder used to construct a list of write
        operations to perform in bulk for a single collection. To instantiate
@@ -283,7 +283,7 @@ Bulk Operation Methods
 
    * - :method:`Bulk.execute()`
 
-     - Executes the list of operations built by the :method:`db.collection.Bulk()`
+     - Executes the list of operations built by the :method:`Bulk()`
        operations builder.
 
    * - :method:`Bulk.find()`

--- a/source/reference/methods.txt
+++ b/source/reference/methods.txt
@@ -251,9 +251,110 @@ Collection Methods
 
      - Modifies multiple documents in a collection.
 
+Bulk Operation Methods
+----------------------
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Method
+
+     - Description
+
+   * - :method:`db.collection.initializeOrderedBulkOp()`
+
+     - Initializes and returns a new :method:`db.collection.Bulk()` operations
+       builder for a collection. The builder constructs an ordered list of
+       write operations that MongoDB executes in bulk.
+
+   * - :method:`db.collection.initializeUnorderedBulkOp()`
+
+     - Initializes and returns a new :method:`db.collection.Bulk()` operations
+       builder for a collection. The builder constructs an unordered list of
+       write operations that MongoDB executes in bulk.
+   
+   * - :method:`db.collection.Bulk()`
+
+     - Creates a bulk operations builder used to construct a list of write
+       operations to perform in bulk for a single collection. To instantiate
+       the builder, use either the :method:`db.collection.initializeOrderedBulkOp()`
+       or the :method:`db.collection.initializeUnorderedBulkOp()` method.
+
+   * - :method:`Bulk.execute()`
+
+     - Executes the list of operations built by the :method:`db.collection.Bulk()`
+       operations builder.
+
+   * - :method:`Bulk.find()`
+
+     - Specifies a query condition for an update or a remove operation.
+
+   * - :method:`Bulk.find.arrayFilters()`
+
+     - Determines which array elements to modify for an update operation
+       on an array field.
+
+   * - :method:`Bulk.find.collation()`
+
+     - Specifies the :manual:`collation
+       </reference/bson-type-comparison-order/#collation>` for the bulk
+       writes. Append to :method:`Bulk.find()` method to specify collation
+       for the find operation.
+
+   * - :method:`Bulk.find.hint()`
+
+     - Sets the **hint** option that specifies the index to support the
+       bulk operation.
+
+   * - :method:`Bulk.find.remove()`
+
+     - Adds a remove operation to a bulk operations list.
+
+   * - :method:`Bulk.find.removeOne()`
+
+     - Adds a single document remove operation to a bulk operations list.
+
+   * - :method:`Bulk.find.replaceOne()`
+
+     - Adds a single document replacement operation to a bulk operations
+       list.
+
+   * - :method:`Bulk.find.updateOne()`
+
+     - Adds a single document update operation to a bulk operations list.
+
+   * - :method:`Bulk.find.update()`
+
+     - Adds a **multi** update operation to a bulk operations list. The
+       method updates specific fields in existing documents.
+
+   * - :method:`Bulk.find.upsert()`
+
+     - Sets the :manual:`upsert </reference/glossary/#term-upsert>` option
+       to ``true`` for an update or a replacement operation.
+
+   * - :method:`Bulk.getOperations()`
+
+     - Returns an array of write operations executed through
+       :method:`Bulk.execute()`.
+
+   * - :method:`Bulk.insert()`
+
+     - Adds an insert operation to a bulk operations list.
+
+   * - :method:`Bulk.tojson()`
+
+     - Returns a JSON document that contains the number of operations and
+       batches in the :method:`Bulk()` object.
+
+   * - :method:`Bulk.tostring()`
+
+     - Returns as a string a JSON document that contains the number of
+       operations and batches in the :method:`Bulk()` object.
+  
 Cursor Methods
 --------------
-
 
 .. list-table::
    :widths: 30 70

--- a/source/reference/methods.txt
+++ b/source/reference/methods.txt
@@ -290,18 +290,6 @@ Bulk Operation Methods
 
      - Specifies a query condition for an update or a remove operation.
 
-   * - :method:`Bulk.find.arrayFilters()`
-
-     - Determines which array elements to modify for an update operation
-       on an array field.
-
-   * - :method:`Bulk.find.collation()`
-
-     - Specifies the :manual:`collation
-       </reference/bson-type-comparison-order/#collation>` for the bulk
-       writes. Append to :method:`Bulk.find()` method to specify collation
-       for the find operation.
-
    * - :method:`Bulk.find.hint()`
 
      - Sets the **hint** option that specifies the index to support the

--- a/source/reference/methods.txt
+++ b/source/reference/methods.txt
@@ -264,7 +264,7 @@ Bulk Operation Methods
 
    * - :method:`db.collection.initializeOrderedBulkOp()`
 
-     - Initializes and returns a new :method:`db.collection.Bulk()` operations
+     - Initializes and returns a new :method:`Bulk <db.collection.Bulk()>` operations
        builder for a collection. The builder constructs an ordered list of
        write operations that MongoDB executes in bulk.
 
@@ -274,7 +274,7 @@ Bulk Operation Methods
        builder for a collection. The builder constructs an unordered list of
        write operations that MongoDB executes in bulk.
    
-   * - :method:`db.collection.Bulk()`
+   * - :method:`Bulk <db.collection.Bulk()>`
 
      - Creates a bulk operations builder used to construct a list of write
        operations to perform in bulk for a single collection. To instantiate


### PR DESCRIPTION
[Jira](https://jira.mongodb.org/browse/DOCSP-11793)
[Staged](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-11793/reference/methods#bulk-operation-methods)