### PR TITLE
(DOCSP-12243): Add Run Commands page and some command behaviors

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -3,7 +3,7 @@ title = "MongoDB Shell"
 
 intersphinx = ["https://docs.mongodb.com/manual/objects.inv"]
 
-toc_landing_pages = ["/crud"]
+toc_landing_pages = ["/run-commands", "/crud"]
 
 [constants]
 

--- a/source/changelog.txt
+++ b/source/changelog.txt
@@ -1,4 +1,4 @@
-.. _mongosh-changelog
+.. _mongosh-changelog:
 
 =====================
 ``mongosh`` Changelog
@@ -58,11 +58,13 @@ the `MongoDB Download Center
 Behavior Updates
 ~~~~~~~~~~~~~~~~
 
-The legacy ``mongo`` shell error handling was not consistent between
-commands. ``mongosh`` now standardizes the user-facing behavior.
 Whenever a shell helper issues a command that results in ``{ ok: 0 }``
 ``mongosh`` throws an exception and does not return the raw output from
 the server.
+
+The legacy ``mongo`` shell error handling was not consistent between
+commands. ``mongosh`` standardizes the user-facing behavior for a
+more consistent experience.
 
 Bug Fixes
 ~~~~~~~~~
@@ -87,7 +89,7 @@ Bug Fixes
   .. note::
 
      ``Ctrl+C`` terminates the process in the shell, but does not
-     terminate the process on the mongodb server.
+     terminate the process on the MongoDB server.
 
 v0.2.2
 ------

--- a/source/changelog.txt
+++ b/source/changelog.txt
@@ -58,11 +58,10 @@ the `MongoDB Download Center
 Behavior Updates
 ~~~~~~~~~~~~~~~~
 
-Whenever a shell helper issues a command that results in ``{ ok: 0 }``
-``mongosh`` throws an exception and does not return the raw output from
-the server.
+Whenever a command's output includes ``{ ok: 0 }``, ``mongosh`` throws
+an exception and does not return the raw output from the server.
 
-The legacy ``mongo`` shell error handling was not consistent between
+The legacy ``mongo`` shell error handling is not consistent between
 commands. ``mongosh`` standardizes the user-facing behavior for a
 more consistent experience.
 

--- a/source/index.txt
+++ b/source/index.txt
@@ -119,8 +119,7 @@ Learn More
       
       /install
       /connect
-      /crud
-      /run-agg-pipelines
+      /run-commands
       /write-scripts
       /logs
       /reference

--- a/source/reference/access-mdb-shell-help.txt
+++ b/source/reference/access-mdb-shell-help.txt
@@ -56,7 +56,9 @@ Show List of Databases
 
      show dbs
 
-  ``show databases`` is an alias for ``show dbs``.
+  .. note::
+
+     ``show databases`` is an alias for ``show dbs``.
 
 Show List of Database Methods
   To see the list of methods you can use on the ``db``

--- a/source/run-commands.txt
+++ b/source/run-commands.txt
@@ -1,0 +1,54 @@
+.. _run-commands:
+
+===========================
+Run Commands in ``mongosh``
+===========================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+.. include:: /includes/admonitions/fact-mdb-shell-beta.rst
+
+For documentation of basic MongoDB operations in ``mongosh``, see:
+
+- :doc:`/crud`
+
+- :doc:`/run-agg-pipelines`
+
+- :doc:`/reference/methods`
+
+Terminate a Running Command
+---------------------------
+
+To terminate a running command or query in ``mongosh``,
+press ``Ctrl + C``.
+
+``Ctrl + C`` terminates the process in the shell, but does not
+terminate the process on the MongoDB server. This behavior
+differs from the :method:`db.killOp()` method, which terminates
+commands on the server.
+
+Command Exceptions
+------------------
+
+In scenarios where the output of a command includes ``{ ok: 0 }``,
+``mongosh`` throws an exception and does not return the raw output from
+the server.
+
+.. note::
+
+   In the legacy ``mongo`` shell, when a command's output was ``{ ok:
+   0}``, the behavior differed between commands. ``mongosh`` provides a
+   more consistent user experience by always throwing an exception in
+   these scenarios.
+
+.. toctree::
+   :titlesonly:
+   
+   /crud
+   /run-agg-pipelines

--- a/source/run-commands.txt
+++ b/source/run-commands.txt
@@ -42,10 +42,10 @@ the server.
 
 .. note::
 
-   In the legacy ``mongo`` shell, when a command's output was
-   ``{ ok: 0}``, the behavior differed between commands. ``mongosh``
-   provides a more consistent user experience by always throwing an
-   exception in these scenarios.
+   In the legacy ``mongo`` shell, when a command's output included ``{
+   ok: 0 }``, the behavior differs between commands. ``mongosh``
+   provides consistent behavior by always throwing an exception in these
+   scenarios.
 
 .. toctree::
    :titlesonly:

--- a/source/run-commands.txt
+++ b/source/run-commands.txt
@@ -28,10 +28,12 @@ Terminate a Running Command
 To terminate a running command or query in ``mongosh``,
 press ``Ctrl + C``.
 
-``Ctrl + C`` terminates the process in the shell, but does not
-terminate the process on the MongoDB server. This behavior
-differs from the :method:`db.killOp()` method, which terminates
-commands on the server.
+.. note::
+
+   ``Ctrl+C`` terminates the process in the shell, but does not
+   terminate the process on the MongoDB server. This behavior
+   differs from the :method:`db.killOp()` method, which terminates
+   commands on the server.
 
 Command Exceptions
 ------------------

--- a/source/run-commands.txt
+++ b/source/run-commands.txt
@@ -42,10 +42,10 @@ the server.
 
 .. note::
 
-   In the legacy ``mongo`` shell, when a command's output was ``{ ok:
-   0}``, the behavior differed between commands. ``mongosh`` provides a
-   more consistent user experience by always throwing an exception in
-   these scenarios.
+   In the legacy ``mongo`` shell, when a command's output was
+   ``{ ok: 0}``, the behavior differed between commands. ``mongosh``
+   provides a more consistent user experience by always throwing an
+   exception in these scenarios.
 
 .. toctree::
    :titlesonly:

--- a/source/run-commands.txt
+++ b/source/run-commands.txt
@@ -28,12 +28,10 @@ Terminate a Running Command
 To terminate a running command or query in ``mongosh``,
 press ``Ctrl + C``.
 
-.. note::
-
-   ``Ctrl+C`` terminates the process in the shell, but does not
-   terminate the process on the MongoDB server. This behavior
-   differs from the :method:`db.killOp()` method, which terminates
-   commands on the server.
+``Ctrl + C`` terminates the process in the shell, but does not
+terminate the process on the MongoDB server. This behavior
+differs from the :method:`db.killOp()` method, which terminates
+commands on the server.
 
 Command Exceptions
 ------------------


### PR DESCRIPTION
New updates for behavior when pressing ctrl+c in the shell, as well as the breaking change (compared to legacy mongo) for Command Exceptions. Moved the CRUD and Agg Pipeline docs to sub-pages of this new page.

Staged: [Run Commands in mongosh](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-12243/run-commands)

Also updated behavior in Changelog. [Staging - v3.0.1 Behavior Updates](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-12243/changelog#v0-3-1)