### PR TITLE
(DOCSP-11649): Update install instructions for .deb and .rpm

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -7,6 +7,8 @@ toc_landing_pages = ["/run-commands", "/crud"]
 
 [constants]
 
+version = "0.4.0"
+
 [substitutions]
 
 2fa = ":abbr:`2FA (Two Factor Authentication)`"

--- a/source/includes/steps-install-shell-base.yaml
+++ b/source/includes/steps-install-shell-base.yaml
@@ -1,20 +1,14 @@
 ---
-title: "Navigate to the MongoDB Download Center."
+title: "Open the MongoDB Shell download page."
 ref: navigate-dlc
 level: 4
 content: |
 
   Open the `MongoDB Download Center
-  <https://www.mongodb.com/download-center/community?jmp=docs>`__.
+  <https://www.mongodb.com/try/download/shell?jmp=docs>`__.
 ---
-title: "Open the |mdb-shell| Download Page."
-ref: open-mdb-shell-page
-level: 4
-content: |
-
-   Click :guilabel:`Tools`, then select :guilabel:`Shell`.
----
-title: "Download the installation archive for your operating system."
+title: "Download the ``mongosh`` installation archive for your
+  operating system."
 ref: download-archive
 level: 4 
 ---
@@ -22,10 +16,13 @@ title: "Extract the files from the downloaded archive."
 ref: extract-archive
 level: 4
 content: |
+
+   Run the following command from the directory containing the
+   ``mongosh`` ``.tgz`` package:
    
    .. code-block:: sh
 
-      tar -zxvf path/to/archive
+      tar -zxvf mongosh-{+version+}-linux.tgz
 
    If your web browser automatically extracts the archive as
    part of the download or you extract the archive without the
@@ -34,7 +31,7 @@ content: |
 
    .. code-block:: sh
 
-      chmod +x /path/to/mongosh
+      chmod +x mongosh
 ---
 title: "Add the ``mongosh`` binary to your ``PATH`` environment
    variable."
@@ -44,21 +41,20 @@ content: |
 
    You can either:
 
-   - Copy the ``mongosh`` binary into a directory listed in your ``PATH``
-     variable, such as ``/usr/local/bin`` (Update
-     ``/path/to/mongosh`` with your installation directory as
-     appropriate)
+   - Copy the ``mongosh`` binary into a directory listed in your
+     ``PATH`` variable, such as ``/usr/local/bin``. Run the following
+     command from the directory containing the ``mongosh`` binary:
 
      .. code-block:: sh
 
-       sudo cp /path/to/mongosh /usr/local/bin/
+       sudo cp mongosh /usr/local/bin/
 
    - Create a symbolic link to the ``mongosh`` binary from a directory
-     listed in your ``PATH`` variable, such as ``/usr/local/bin``
-     (Update ``/path/to/mongosh`` with your installation directory as
-     appropriate):
+     listed in your ``PATH`` variable, such as ``/usr/local/bin``.
+     Run the following command from the directory containing the
+     ``mongosh`` binary:
 
      .. code-block:: sh
 
-       sudo ln -s  /path/to/mongosh /usr/local/bin/
+       sudo ln -s mongosh /usr/local/bin/
 ...

--- a/source/includes/steps-install-shell-linux-deb.yaml
+++ b/source/includes/steps-install-shell-linux-deb.yaml
@@ -12,15 +12,10 @@ title: "Extract and install the ``.deb`` package."
 ref: extract-archive-linux-deb
 level: 4
 content: |
-  To install the downloaded ``.deb`` package, either:
+  To install the |mdb-shell|, run the following command from the
+  directory containing the ``mongosh`` ``.deb`` package:
 
-  - Double click your downloaded ``.deb`` package icon and follow
-    the prompts.
+  .. code-block:: sh
 
-  - Run the following command from the directory containing the
-    ``mongosh`` ``.deb`` package:
-
-    .. code-block:: sh
-
-       sudo dpkg --install mongosh_{+version+}_amd64.deb
+      sudo dpkg --install mongosh_{+version+}_amd64.deb
 ...

--- a/source/includes/steps-install-shell-linux-deb.yaml
+++ b/source/includes/steps-install-shell-linux-deb.yaml
@@ -4,15 +4,9 @@ source:
   ref: navigate-dlc
 ref: navigate-dlc-linux-deb
 ---
-source:
-  file: steps-install-shell-base.yaml
-  ref: open-mdb-shell-page
-ref: open-mdb-shell-page-linux-deb
----
-source:
-  file: steps-install-shell-base.yaml
-  ref: download-archive
-ref: download-archive-generic-linux
+title: "Download the Debian 64-bit ``.deb`` package."
+ref: download-archive-rhel
+level: 4 
 ---
 title: "Extract and install the ``.deb`` package."
 ref: extract-archive-linux-deb
@@ -23,9 +17,10 @@ content: |
   - Double click your downloaded ``.deb`` package icon and follow
     the prompts.
 
-  - Run the following command from the terminal:
+  - Run the following command from the directory containing the
+    ``mongosh`` ``.deb`` package:
 
     .. code-block:: sh
 
-       sudo dpkg --install path/to/mongosh_<version>_.deb
+       sudo dpkg --install mongosh_{+version+}_amd64.deb
 ...

--- a/source/includes/steps-install-shell-linux-deb.yaml
+++ b/source/includes/steps-install-shell-linux-deb.yaml
@@ -1,0 +1,31 @@
+---
+source:
+  file: steps-install-shell-base.yaml
+  ref: navigate-dlc
+ref: navigate-dlc-linux-deb
+---
+source:
+  file: steps-install-shell-base.yaml
+  ref: open-mdb-shell-page
+ref: open-mdb-shell-page-linux-deb
+---
+source:
+  file: steps-install-shell-base.yaml
+  ref: download-archive
+ref: download-archive-generic-linux
+---
+title: "Extract and install the ``.deb`` package."
+ref: extract-archive-linux-deb
+level: 4
+content: |
+  To install the downloaded ``.deb`` package, either:
+
+  - Double click your downloaded ``.deb`` package icon and follow
+    the prompts.
+
+  - Run the following command from the terminal:
+
+    .. code-block:: sh
+
+       sudo dpkg --install path/to/mongosh_<version>_.deb
+...

--- a/source/includes/steps-install-shell-linux-generic.yaml
+++ b/source/includes/steps-install-shell-linux-generic.yaml
@@ -4,15 +4,9 @@ source:
   ref: navigate-dlc
 ref: navigate-dlc-generic-linux
 ---
-source:
-  file: steps-install-shell-base.yaml
-  ref: open-mdb-shell-page
-ref: open-mdb-shell-page-generic-linux
----
-source:
-  file: steps-install-shell-base.yaml
-  ref: download-archive
-ref: download-archive-generic-linux
+title: "Download the Linux 64-bit ``.tgz`` package."
+ref: download-archive-rhel
+level: 4 
 ---
 source:
   file: steps-install-shell-base.yaml

--- a/source/includes/steps-install-shell-linux-generic.yaml
+++ b/source/includes/steps-install-shell-linux-generic.yaml
@@ -23,5 +23,4 @@ source:
   file: steps-install-shell-base.yaml
   ref: add-shell-to-path
 ref: add-shell-to-path-generic-linux
-
 ...

--- a/source/includes/steps-install-shell-linux-rpm.yaml
+++ b/source/includes/steps-install-shell-linux-rpm.yaml
@@ -17,5 +17,5 @@ content: |
 
   .. code-block:: sh
 
-     sudo yum install mongosh-{+version+}-x86_64.rpm
+     sudo yum install -y mongosh-{+version+}-x86_64.rpm
 ...

--- a/source/includes/steps-install-shell-linux-rpm.yaml
+++ b/source/includes/steps-install-shell-linux-rpm.yaml
@@ -4,23 +4,18 @@ source:
   ref: navigate-dlc
 ref: navigate-dlc-linux-rpm
 ---
-source:
-  file: steps-install-shell-base.yaml
-  ref: open-mdb-shell-page
-ref: open-mdb-shell-page-linux-rpm
----
-source:
-  file: steps-install-shell-base.yaml
-  ref: download-archive
-ref: download-archive-generic-linux
+title: "Download the Red Hat 64-bit ``.rpm`` package."
+ref: download-archive-rhel
+level: 4 
 ---
 title: "Extract and install the ``.rpm`` package."
 ref: extract-archive-rpm
 level: 4
 content: |
-  Run the following command to install the |mdb-shell|:
+  To install the |mdb-shell|, run the following command from the
+  directory containing the ``mongosh`` ``.rpm`` package:
 
   .. code-block:: sh
 
-     sudo yum install mongosh-0.4.0-x86_64.rpm
+     sudo yum install mongosh-{+version+}-x86_64.rpm
 ...

--- a/source/includes/steps-install-shell-linux-rpm.yaml
+++ b/source/includes/steps-install-shell-linux-rpm.yaml
@@ -1,0 +1,26 @@
+---
+source:
+  file: steps-install-shell-base.yaml
+  ref: navigate-dlc
+ref: navigate-dlc-linux-rpm
+---
+source:
+  file: steps-install-shell-base.yaml
+  ref: open-mdb-shell-page
+ref: open-mdb-shell-page-linux-rpm
+---
+source:
+  file: steps-install-shell-base.yaml
+  ref: download-archive
+ref: download-archive-generic-linux
+---
+title: "Extract and install the ``.rpm`` package."
+ref: extract-archive-rpm
+level: 4
+content: |
+  Run the following command to install the |mdb-shell|:
+
+  .. code-block:: sh
+
+     sudo yum install mongosh-0.4.0-x86_64.rpm
+...

--- a/source/includes/steps-install-shell-macos.yaml
+++ b/source/includes/steps-install-shell-macos.yaml
@@ -6,11 +6,6 @@ ref: navigate-dlc-macos
 ---
 source:
   file: steps-install-shell-base.yaml
-  ref: open-mdb-shell-page
-ref: open-mdb-shell-page-macos
----
-source:
-  file: steps-install-shell-base.yaml
   ref: download-archive
 ref: download-archive-macos
 ---

--- a/source/includes/steps-install-shell-windows.yaml
+++ b/source/includes/steps-install-shell-windows.yaml
@@ -26,7 +26,7 @@ content: |
    To add the |mdb-shell| binary's location to your 
    ``PATH`` environment variable:
 
-   1. Open the :guilabel:`Control Panel`.
+   a. Open the :guilabel:`Control Panel`.
 
    #. In the :guilabel:`System and Security` category, click 
       :guilabel:`System`.

--- a/source/includes/steps-install-shell-windows.yaml
+++ b/source/includes/steps-install-shell-windows.yaml
@@ -6,11 +6,6 @@ ref: navigate-dlc-windows
 ---
 source:
   file: steps-install-shell-base.yaml
-  ref: open-mdb-shell-page
-ref: open-mdb-shell-page-windows
----
-source:
-  file: steps-install-shell-base.yaml
   ref: download-archive
 ref: download-archive-windows
 ---
@@ -18,7 +13,7 @@ title: "Extract the files from the downloaded archive."
 ref: extract-archive
 level: 4
 ---
-title: "Add the MongoDB Shell binary to your ``PATH`` environment
+title: "Add the ``mongosh`` binary to your ``PATH`` environment
    variable."
 ref: add-shell-to-path
 level: 4

--- a/source/install.txt
+++ b/source/install.txt
@@ -72,8 +72,15 @@ Procedure
    .. tab::
       :tabid: linux
 
-      Select your desired Linux installation package from the tabs
-      below:
+      Select the appropriate tab based on your Linux distribution and
+      desired package:
+
+      - For TGZ tarball installation, click the ``.tgz`` tab.
+
+      - For installation on Ubuntu and Debian, click the ``.deb`` tab.
+
+      - For installation on :abbr:`RHEL (Red Hat Enterprise Linux)`,
+        click the ``.rpm`` tab.
 
       .. tabs::
       
@@ -82,12 +89,12 @@ Procedure
       
             .. include:: /includes/steps/install-shell-linux-generic.rst
 
-         .. tab:: .deb (Debian)
+         .. tab:: .deb
             :tabid: deb
 
             .. include:: /includes/steps/install-shell-linux-deb.rst
 
-         .. tab:: .rpm (RHEL)
+         .. tab:: .rpm
             :tabid: rpm
             
             .. include:: /includes/steps/install-shell-linux-rpm.rst

--- a/source/install.txt
+++ b/source/install.txt
@@ -71,8 +71,26 @@ Procedure
 
    .. tab::
       :tabid: linux
+
+      Select your desired Linux installation package from the tabs
+      below:
+
+      .. tabs::
       
-      .. include:: /includes/steps/install-shell-generic-linux.rst
+         .. tab:: .tgz
+            :tabid: tgz
+      
+            .. include:: /includes/steps/install-shell-linux-generic.rst
+
+         .. tab:: .deb (Debian)
+            :tabid: deb
+
+            .. include:: /includes/steps/install-shell-linux-deb.rst
+
+         .. tab:: .rpm (RHEL)
+            :tabid: rpm
+            
+            .. include:: /includes/steps/install-shell-linux-rpm.rst
 
 Next Steps
 ----------

--- a/source/install.txt
+++ b/source/install.txt
@@ -73,22 +73,19 @@ Procedure
       :tabid: linux
 
       Select the appropriate tab based on your Linux distribution and
-      desired package:
+      desired package from the tabs below:
 
-      - For TGZ tarball installation, click the ``.tgz`` tab.
+      - To install the ``.deb`` package on Ubuntu and Debian,
+        click the ``.deb`` tab.
+      
+      - To install the ``.rpm`` package on
+        :abbr:`RHEL (Red Hat Enterprise Linux)`, click the
+        ``.rpm`` tab.
 
-      - For installation on Ubuntu and Debian, click the ``.deb`` tab.
-
-      - For installation on :abbr:`RHEL (Red Hat Enterprise Linux)`,
-        click the ``.rpm`` tab.
+      - To install the ``.tgz`` tarball, click the ``.tgz`` tab.
 
       .. tabs::
       
-         .. tab:: .tgz
-            :tabid: tgz
-      
-            .. include:: /includes/steps/install-shell-linux-generic.rst
-
          .. tab:: .deb
             :tabid: deb
 
@@ -98,6 +95,11 @@ Procedure
             :tabid: rpm
             
             .. include:: /includes/steps/install-shell-linux-rpm.rst
+
+         .. tab:: .tgz
+            :tabid: tgz
+      
+            .. include:: /includes/steps/install-shell-linux-generic.rst
 
 Next Steps
 ----------


### PR DESCRIPTION
Added tabs to the Linux tab for each package / Linux distro supported. If you think there's a better way to structure this, happy to discuss.

Staged: [Install mongosh](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-11649/install#install-mongosh)