### PR TITLE
DOCSP-12627: [MONGOSH] Transaction, Session, and Replica Set Config methods

### DIFF
--- a/source/reference/methods.txt
+++ b/source/reference/methods.txt
@@ -750,7 +750,7 @@ Replication Methods
 
      - Adds an arbiter to an existing replica set.
 
-   * - ``:method:`rs.config() </reference/method/rs.config/>```
+   * - :method:`rs.config()`
 
      - Returns a document that contains the current replica set configuration.
 

--- a/source/reference/methods.txt
+++ b/source/reference/methods.txt
@@ -730,6 +730,42 @@ Query Plan Cache Methods
        :manual:`plan cache entries </core/query-plans/>` 
        for a collection.
 
+Session Object Methods
+----------------------
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Method
+
+     - Description
+
+   * - :manual:`Session.advanceOperationTime() </reference/method/Session>`
+
+     - Updates the operation time.
+
+   * - :manual:`Session.endSession() </reference/method/Session>`
+
+     - Ends the session.
+
+   * - :manual:`Session.getClusterTime() </reference/method/Session>`
+
+     - Returns the most recent cluster time as seen by the session. 
+
+   * - :manual:`Session.getOperationTime() </reference/method/Session>`
+
+     - Returns the timestamp of the last acknowledged operation for the
+       session.
+
+   * - :manual:`Session.getOptions() </reference/method/Session>`
+
+     - Returns the options for the session. 
+
+   * - :manual:`Session.hasEnded() </reference/method/Session>`
+
+     - Returns a boolean that specifies whether the session has ended.
+
 Server Status Methods
 ---------------------
 
@@ -833,6 +869,33 @@ Sharding Methods
 
      - Associates a range of shard keys with a zone. Supports configuring
        zones in sharded clusters.
+
+Transaction Methods
+-------------------
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Method
+
+     - Description
+
+   * - :method:`Session.abortTransaction()`
+
+     - Terminates a :manual:`multi-document transaction </core/transactions/>`
+       and rolls back any data changes made by the operations within the
+       transaction.
+
+   * - :method:`Session.commitTransaction()`
+
+     - Saves the changes made by the operations in a :manual:`multi-document
+       transaction </core/transactions/>` and ends the transaction.
+
+   * - :method:`Session.startTransaction()`
+
+     - Starts a :manual:`multi-document transaction </core/transactions/>`
+       associated with the session.
 
 User Management Methods
 -----------------------
@@ -969,9 +1032,9 @@ Replication Methods
 
      - Adds an arbiter to an existing replica set.
 
-   * - :method:`rs.config()`
+   * - :manual:`rs.config() </reference/method/rs.conf/>`
 
-     - Applies a new configuration to an existing replica set.
+     - Returns a document that contains the current replica set configuration.
 
    * - :method:`rs.freeze()`
 
@@ -1062,6 +1125,10 @@ Replication Methods
             syncedTo: 'Tue Oct 13 2020 09:42:18 GMT-0700 (Pacific Daylight Time)',
             replLag: '0 secs (0 hrs) behind the primary '
           }
+
+   * - :manual:`rs.reconfig() </reference/command/replSetReconfig/>`
+
+     - Modifies the configuration of an existing replica set.
 
    * - :method:`rs.remove()`
 

--- a/source/reference/methods.txt
+++ b/source/reference/methods.txt
@@ -730,6 +730,197 @@ Query Plan Cache Methods
        :manual:`plan cache entries </core/query-plans/>` 
        for a collection.
 
+Replication Methods 
+-------------------
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Method
+
+     - Description
+
+   * - :method:`rs.add()`
+
+     - Adds a member to the replica set. You must connect to the 
+       primary of the replica set to run this method.
+
+   * - :method:`rs.addArb()`
+
+     - Adds an arbiter to an existing replica set.
+
+   * - ``:method:`rs.config() </reference/method/rs.config/>```
+
+     - Returns a document that contains the current replica set configuration.
+
+   * - :method:`rs.freeze()`
+
+     - Makes the replica set member that ``mongosh`` is connected to 
+       ineligible to become primary for the specified duration. The 
+       duration must be specified in seconds.
+
+   * - :method:`db.getReplicationInfo()`
+
+     - Returns the status of the replica set from the oplog data.
+
+   * - :method:`rs.initiate()`
+
+     - Initializes a new replica set.
+
+   * - ``rs.isMaster``
+
+     - Returns the replica set configuration, role, and status for 
+       the ``mongod`` instance that ``mongosh`` is connected to. 
+       
+       The ``mongosh`` ``rs.isMaster()`` method wraps the server :dbcommand:`isMaster` command.
+
+   * - :method:`db.printReplicationInfo()`
+
+     - Returns the oplog of the replica set member that ``mongosh`` is 
+       connected to. 
+       
+       This is identical to the :method:`rs.printReplicationInfo()` method.
+
+   * - :method:`rs.printReplicationInfo()`
+
+     - Returns the oplog of the replica set member that ``mongosh`` is 
+       connected to. 
+       
+       This is identical to the :method:`db.printReplicationInfo()` method.
+
+   * - ``db.printSecondaryReplicationInfo``
+
+     - Returns the status of the secondary members of the replica set. 
+     
+       This is identical to the ``rs.printSecondaryReplicationInfo()`` method. 
+       This method's output is similar to the 
+       :method:`db.printSlaveReplicationInfo()` method. The :method:`db.printSlaveReplicationInfo()` method is deprecated in ``mongosh``. Use 
+       ``db.printSecondaryReplicationInfo()`` instead.
+
+       The following is an example output from the 
+       ``rs.printSecondaryReplicationInfo()`` method issued on a replica set with two secondary members:
+
+       .. code-block:: sh 
+          :copyable: false 
+
+          source: rs2.example.net:27017
+          {
+            syncedTo: 'Tue Oct 13 2020  09:37:28 GMT-0700 (Pacific Daylight Time)',
+            replLag: '0 secs (0 hrs) behind the primary '
+          }
+          ---
+          source: rs3.example.net:27017
+          {
+            syncedTo: 'Tue Oct 13 2020  09:37:28 GMT-0700 (Pacific Daylight Time)',
+            replLag: '0 secs (0 hrs) behind the primary '
+          }
+
+   * - ``rs.printSecondaryReplicationInfo``
+
+     - Returns the status of the secondary members of the replica set. 
+     
+       This is identical to the ``db.printSecondaryReplicationInfo()`` 
+       method. This method's output is similar to the 
+       :method:`rs.printSlaveReplicationInfo()` method in the legacy 
+       :binary:`~mongo` shell. The :method:`rs.printSlaveReplicationInfo()` method is deprecated in ``mongosh``. Use 
+       ``rs.printSecondaryReplicationInfo()`` instead.
+
+       The following is an example output from the 
+       ``rs.printSecondaryReplicationInfo()`` method issued on a replica set with two secondary members:
+
+       .. code-block:: sh 
+          :copyable: false 
+
+          source: rs2.example.net:27017
+          {
+            syncedTo: 'Tue Oct 13 2020 09:42:18 GMT-0700 (Pacific Daylight Time)',
+            replLag: '0 secs (0 hrs) behind the primary '
+          }
+          ---
+          source: rs3.example.net:27017
+          {
+            syncedTo: 'Tue Oct 13 2020 09:42:18 GMT-0700 (Pacific Daylight Time)',
+            replLag: '0 secs (0 hrs) behind the primary '
+          }
+
+   * - :manual:`rs.reconfig() </reference/command/replSetReconfig/>`
+
+     - Modifies the configuration of an existing replica set.
+
+   * - :method:`rs.remove()`
+
+     - Removes the member specified by hostname from the replica set.
+
+   * - :method:`rs.status()`
+
+     - Returns the status of the replica set member that ``mongosh`` is 
+       connected to. 
+
+   * - :method:`rs.stepDown()`
+
+     - Makes the primary of the replica set a secondary. You must be 
+       connected to the primary to run this method.
+
+   * - :method:`rs.syncFrom()`
+
+     - Resets the sync target to the replica set member specified 
+       by hostname for the replica set member that ``mongosh`` is 
+       connected to.
+
+Role Management Methods 
+-----------------------
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Method
+
+     - Description
+ 
+   * - :method:`db.createRole()`
+
+     - Creates a role and specifies its privileges.
+
+   * - :method:`db.dropRole()`
+
+     - Deletes a user-defined role.
+
+   * - :method:`db.dropAllRoles()`
+
+     - Deletes all user-defined roles associated with a database.
+
+   * - :method:`db.getRole()`
+
+     - Returns information for the specified role.
+
+   * - :method:`db.getRoles()`
+
+     - Returns information for all the user-defined roles in a
+       database. 
+
+   * - :method:`db.grantPrivilegesToRole()`
+
+     - Assigns privileges to a user-defined role.
+   
+   * - :method:`db.revokePrivilegesFromRole()`
+
+     - Removes the specified privileges from a user-defined role.
+   
+   * - :method:`db.grantRolesToRole()`
+
+     - Specifies roles from which a user-defined role inherits
+       privileges.
+   
+   * - :method:`db.revokeRolesFromRole()`
+
+     - Removes inherited roles from a role.
+
+   * - :method:`db.updateRole()`
+
+     - Updates a user-defined role.
+
 Session Object Methods
 ----------------------
 
@@ -958,195 +1149,3 @@ User Management Methods
    * - :method:`db.revokeRolesFromUser()`
 
      - Removes a role from a user.
-
-Role Management Methods 
------------------------
-
-.. list-table::
-   :widths: 30 70
-   :header-rows: 1
-
-   * - Method
-
-     - Description
- 
-   * - :method:`db.createRole()`
-
-     - Creates a role and specifies its privileges.
-
-   * - :method:`db.dropRole()`
-
-     - Deletes a user-defined role.
-
-   * - :method:`db.dropAllRoles()`
-
-     - Deletes all user-defined roles associated with a database.
-
-   * - :method:`db.getRole()`
-
-     - Returns information for the specified role.
-
-   * - :method:`db.getRoles()`
-
-     - Returns information for all the user-defined roles in a
-       database. 
-
-   * - :method:`db.grantPrivilegesToRole()`
-
-     - Assigns privileges to a user-defined role.
-   
-   * - :method:`db.revokePrivilegesFromRole()`
-
-     - Removes the specified privileges from a user-defined role.
-   
-   * - :method:`db.grantRolesToRole()`
-
-     - Specifies roles from which a user-defined role inherits
-       privileges.
-   
-   * - :method:`db.revokeRolesFromRole()`
-
-     - Removes inherited roles from a role.
-
-   * - :method:`db.updateRole()`
-
-     - Updates a user-defined role.
-
-Replication Methods 
--------------------
-
-.. list-table::
-   :widths: 30 70
-   :header-rows: 1
-
-   * - Method
-
-     - Description
-
-   * - :method:`rs.add()`
-
-     - Adds a member to the replica set. You must connect to the 
-       primary of the replica set to run this method.
-
-   * - :method:`rs.addArb()`
-
-     - Adds an arbiter to an existing replica set.
-
-   * - :manual:`rs.config() </reference/method/rs.conf/>`
-
-     - Returns a document that contains the current replica set configuration.
-
-   * - :method:`rs.freeze()`
-
-     - Makes the replica set member that ``mongosh`` is connected to 
-       ineligible to become primary for the specified duration. The 
-       duration must be specified in seconds.
-
-   * - :method:`db.getReplicationInfo()`
-
-     - Returns the status of the replica set from the oplog data.
-
-   * - :method:`rs.initiate()`
-
-     - Initializes a new replica set.
-
-   * - ``rs.isMaster``
-
-     - Returns the replica set configuration, role, and status for 
-       the ``mongod`` instance that ``mongosh`` is connected to. 
-       
-       The ``mongosh`` ``rs.isMaster()`` method wraps the server :dbcommand:`isMaster` command.
-
-   * - :method:`db.printReplicationInfo()`
-
-     - Returns the oplog of the replica set member that ``mongosh`` is 
-       connected to. 
-       
-       This is identical to the :method:`rs.printReplicationInfo()` method.
-
-   * - :method:`rs.printReplicationInfo()`
-
-     - Returns the oplog of the replica set member that ``mongosh`` is 
-       connected to. 
-       
-       This is identical to the :method:`db.printReplicationInfo()` method.
-
-   * - ``db.printSecondaryReplicationInfo``
-
-     - Returns the status of the secondary members of the replica set. 
-     
-       This is identical to the ``rs.printSecondaryReplicationInfo()`` method. 
-       This method's output is similar to the 
-       :method:`db.printSlaveReplicationInfo()` method. The :method:`db.printSlaveReplicationInfo()` method is deprecated in ``mongosh``. Use 
-       ``db.printSecondaryReplicationInfo()`` instead.
-
-       The following is an example output from the 
-       ``rs.printSecondaryReplicationInfo()`` method issued on a replica set with two secondary members:
-
-       .. code-block:: sh 
-          :copyable: false 
-
-          source: rs2.example.net:27017
-          {
-            syncedTo: 'Tue Oct 13 2020  09:37:28 GMT-0700 (Pacific Daylight Time)',
-            replLag: '0 secs (0 hrs) behind the primary '
-          }
-          ---
-          source: rs3.example.net:27017
-          {
-            syncedTo: 'Tue Oct 13 2020  09:37:28 GMT-0700 (Pacific Daylight Time)',
-            replLag: '0 secs (0 hrs) behind the primary '
-          }
-
-   * - ``rs.printSecondaryReplicationInfo``
-
-     - Returns the status of the secondary members of the replica set. 
-     
-       This is identical to the ``db.printSecondaryReplicationInfo()`` 
-       method. This method's output is similar to the 
-       :method:`rs.printSlaveReplicationInfo()` method in the legacy 
-       :binary:`~mongo` shell. The :method:`rs.printSlaveReplicationInfo()` method is deprecated in ``mongosh``. Use 
-       ``rs.printSecondaryReplicationInfo()`` instead.
-
-       The following is an example output from the 
-       ``rs.printSecondaryReplicationInfo()`` method issued on a replica set with two secondary members:
-
-       .. code-block:: sh 
-          :copyable: false 
-
-          source: rs2.example.net:27017
-          {
-            syncedTo: 'Tue Oct 13 2020 09:42:18 GMT-0700 (Pacific Daylight Time)',
-            replLag: '0 secs (0 hrs) behind the primary '
-          }
-          ---
-          source: rs3.example.net:27017
-          {
-            syncedTo: 'Tue Oct 13 2020 09:42:18 GMT-0700 (Pacific Daylight Time)',
-            replLag: '0 secs (0 hrs) behind the primary '
-          }
-
-   * - :manual:`rs.reconfig() </reference/command/replSetReconfig/>`
-
-     - Modifies the configuration of an existing replica set.
-
-   * - :method:`rs.remove()`
-
-     - Removes the member specified by hostname from the replica set.
-
-   * - :method:`rs.status()`
-
-     - Returns the status of the replica set member that ``mongosh`` is 
-       connected to. 
-
-   * - :method:`rs.stepDown()`
-
-     - Makes the primary of the replica set a secondary. You must be 
-       connected to the primary to run this method.
-
-   * - :method:`rs.syncFrom()`
-
-     - Resets the sync target to the replica set member specified 
-       by hostname for the replica set member that ``mongosh`` is 
-       connected to.
-

--- a/source/reference/methods.txt
+++ b/source/reference/methods.txt
@@ -969,6 +969,10 @@ Replication Methods
 
      - Adds an arbiter to an existing replica set.
 
+   * - :method:`rs.config()`
+
+     - Applies a new configuration to an existing replica set.
+
    * - :method:`rs.freeze()`
 
      - Makes the replica set member that ``mongosh`` is connected to 
@@ -978,6 +982,10 @@ Replication Methods
    * - :method:`db.getReplicationInfo()`
 
      - Returns the status of the replica set from the oplog data.
+
+   * - :method:`rs.initiate()`
+
+     - Initializes a new replica set.
 
    * - ``rs.isMaster``
 

--- a/source/reference/methods.txt
+++ b/source/reference/methods.txt
@@ -757,8 +757,8 @@ Replication Methods
    * - :method:`rs.freeze()`
 
      - Makes the replica set member that ``mongosh`` is connected to 
-       ineligible to become primary for the specified duration. The 
-       duration must be specified in seconds.
+       ineligible to become primary for the specified duration. You 
+       must specify the duration in seconds.
 
    * - :method:`db.getReplicationInfo()`
 
@@ -768,10 +768,10 @@ Replication Methods
 
      - Initializes a new replica set.
 
-   * - ``rs.isMaster``
+   * - ``rs.isMaster()``
 
      - Returns the replica set configuration, role, and status for 
-       the ``mongod`` instance that ``mongosh`` is connected to. 
+       the |mongod| instance that ``mongosh`` is connected to. 
        
        The ``mongosh`` ``rs.isMaster()`` method wraps the server :dbcommand:`isMaster` command.
 
@@ -780,15 +780,11 @@ Replication Methods
      - Returns the oplog of the replica set member that ``mongosh`` is 
        connected to. 
        
-       This is identical to the :method:`rs.printReplicationInfo()` method.
-
    * - :method:`rs.printReplicationInfo()`
 
      - Returns the oplog of the replica set member that ``mongosh`` is 
        connected to. 
        
-       This is identical to the :method:`db.printReplicationInfo()` method.
-
    * - ``db.printSecondaryReplicationInfo``
 
      - Returns the status of the secondary members of the replica set. 
@@ -823,7 +819,7 @@ Replication Methods
        This is identical to the ``db.printSecondaryReplicationInfo()`` 
        method. This method's output is similar to the 
        :method:`rs.printSlaveReplicationInfo()` method in the legacy 
-       :binary:`~mongo` shell. The :method:`rs.printSlaveReplicationInfo()` method is deprecated in ``mongosh``. Use 
+       |mongo| shell. The :method:`rs.printSlaveReplicationInfo()` method is deprecated in ``mongosh``. Use 
        ``rs.printSecondaryReplicationInfo()`` instead.
 
        The following is an example output from the 


### PR DESCRIPTION
Includes [DOCSP-13309](https://jira.mongodb.org/browse/DOCSP-13309), [DOCSP-13311](https://jira.mongodb.org/browse/DOCSP-13311), and [DOCSP-12627](https://jira.mongodb.org/browse/DOCSP-12627).

[Staged](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-12627/reference/methods)