### PR TITLE
DOCSP-13551: [MONGOSH] Support readConcern on cursor

### DIFF
--- a/source/reference/methods.txt
+++ b/source/reference/methods.txt
@@ -509,6 +509,10 @@ Cursor Methods
 
      - Returns the number of documents left in the current cursor batch.
 
+   * - :method:`cursor.readConcern()`
+
+     - Specifies a :term:`read concern` for a :method:`find()` operation.
+
    * - :method:`cursor.readPref()`
 
      - Specifies a :term:`read preference` to a cursor to control how


### PR DESCRIPTION
[Jira](https://jira.mongodb.org/browse/DOCSP-13551)
[Staged](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-13551/reference/methods)