### PR TITLE
(DOCSP-13189): Remove deprecated CRUD commands

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -124,3 +124,4 @@ Learn More
       /logs
       /reference
       /changelog
+      /reference/compatibility

--- a/source/logs.txt
+++ b/source/logs.txt
@@ -1,8 +1,8 @@
 .. _mdb-shell-logs:
 
-===========================
-Retrieve MongoDB Shell Logs
-===========================
+===================
+Retrieve Shell Logs
+===================
 
 .. default-domain:: mongodb
 

--- a/source/reference/compatibility.txt
+++ b/source/reference/compatibility.txt
@@ -35,6 +35,7 @@ the methods listed in the :guilabel:`Alternative Methods` column.
    * - ``db.collection.remove()``
      - - :method:`db.collection.deleteOne()`
        - :method:`db.collection.deleteMany()`
+       - :method:`db.collection.findOneAndDelete()`
        - :method:`db.collection.bulkWrite()`
 
    * - ``db.collection.save()``
@@ -42,10 +43,12 @@ the methods listed in the :guilabel:`Alternative Methods` column.
        - :method:`db.collection.insertMany()`
        - :method:`db.collection.updateOne()`
        - :method:`db.collection.updateMany()`
+       - :method:`db.collection.findOneAndUpdate()`
 
 
    * - ``db.collection.update()``
      - - :method:`db.collection.updateOne()`
        - :method:`db.collection.updateMany()`
+       - :method:`db.collection.findOneAndUpdate()`
        - :method:`db.collection.bulkWrite()`
 

--- a/source/reference/compatibility.txt
+++ b/source/reference/compatibility.txt
@@ -1,0 +1,51 @@
+.. _compatibility:
+
+=================================================
+Compatibility Changes with Legacy ``mongo`` Shell
+=================================================
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+The following behaviors in ``mongosh`` affect compatibility with
+operations performed in the legacy ``mongo`` shell.
+
+Deprecated Methods
+------------------
+
+The following shell methods are deprecated in ``mongosh``. Instead, use
+the methods listed in the :guilabel:`Alternative Methods` column.
+
+.. list-table::
+   :header-rows: 1
+   :stub-columns: 1
+   :widths: 10 10
+
+   * - Deprecated Method
+     - Alternative Methods
+   
+   * - ``db.collection.insert()``
+     - - :method:`db.collection.insertOne()`
+       - :method:`db.collection.insertMany()`
+       - :method:`db.collection.bulkWrite()`
+
+   * - ``db.collection.remove()``
+     - - :method:`db.collection.deleteOne()`
+       - :method:`db.collection.deleteMany()`
+       - :method:`db.collection.bulkWrite()`
+
+   * - ``db.collection.save()``
+     - - :method:`db.collection.insertOne()`
+       - :method:`db.collection.insertMany()`
+       - :method:`db.collection.updateOne()`
+       - :method:`db.collection.updateMany()`
+
+
+   * - ``db.collection.update()``
+     - - :method:`db.collection.updateOne()`
+       - :method:`db.collection.updateMany()`
+       - :method:`db.collection.bulkWrite()`
+

--- a/source/reference/methods.txt
+++ b/source/reference/methods.txt
@@ -278,10 +278,6 @@ Collection Methods
      - Provides a wrapper for the database command :manual:`getShardVersion
        </reference/command/getShardVersion/>`.
 
-   * - :method:`db.collection.insert()`
-
-     - Creates a new document in a collection.
-
    * - :method:`db.collection.insertOne()`
 
      - Inserts a new document in a collection.
@@ -302,10 +298,6 @@ Collection Methods
 
      - Rebuilds all existing indexes on a collection.
 
-   * - :method:`db.collection.remove()`
-
-     - Deletes documents from a collection.
-
    * - :method:`db.collection.renameCollection()`
 
      - Changes the name of a collection.
@@ -313,11 +305,6 @@ Collection Methods
    * - :method:`db.collection.replaceOne()`
 
      - Replaces a single document in a collection.
-
-   * - :method:`db.collection.save()`
-
-     - Provides a wrapper around :method:`~db.collection.insert()`
-       and :method:`~db.collection.update()` to insert new documents.
 
    * - :method:`db.collection.stats()`
 
@@ -340,10 +327,6 @@ Collection Methods
 
      - Reports the total size of a collection, including the size of
        all documents and all indexes on a collection.
-
-   * - :method:`db.collection.update()`
-
-     - Modifies a document in a collection.
 
    * - :method:`db.collection.updateOne()`
 

--- a/source/write-scripts.txt
+++ b/source/write-scripts.txt
@@ -1,7 +1,7 @@
 .. _mdb-shell-write-scripts:
 
 =================================
-Write Scripts for the |mdb-shell|
+Write Scripts for the ``mongosh``
 =================================
 
 .. default-domain:: mongodb


### PR DESCRIPTION
This is the first addition to what will ultimately be a page describing all compatibility changes between the mongo shell and mongosh. Currently I just put this on the top level ToC, but we may find that it lives better under Reference, or some other section.

Also did a bit of tweaking to some page titles.

JIRA: [DOCSP-13189](https://jira.mongodb.org/browse/DOCSP-13189)

Staged: [Compatibility Changes](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-13189/reference/compatibility)