### PR TITLE
FLE documentation updates

### DIFF
--- a/source/install.txt
+++ b/source/install.txt
@@ -60,6 +60,16 @@ Procedure
       ``mongosh`` from an archive instead, see
       :ref:`macos-install-archive`.
 
+      Considerations
+      ``````````````
+
+      ``mongosh`` installed with Homebrew does not support
+      :manual:`automatic client-side field level encryption
+      </core/security-automatic-client-side-encryption/>`.
+
+      Procedure
+      `````````
+
       To install ``mongosh`` with Homebrew:
 
       .. include:: /includes/steps/install-shell-macos-homebrew.rst

--- a/source/reference/methods.txt
+++ b/source/reference/methods.txt
@@ -356,6 +356,62 @@ Connection Methods
 
      - Description
 
+   * - :method:`Mongo()`
+
+     - JavaScript constructor to instantiate a database connection from
+       the ``mongo`` shell or from a JavaScript file.
+
+       The :method:`Mongo()` method takes a parameter called
+       ``ClientSideFieldLevelEncryptionOptions``, with the following options:
+
+       .. list-table::
+          :widths: 15 20 40
+          :header-rows: 1
+
+          * - Option
+
+            - Type
+
+            - Description
+
+          * - ``keyVaultClient``
+
+            - :method:`Mongo()` connection object
+
+            - *(Optional)* The MongoDB cluster hosting the key vault
+              collection. Omit to use the current database connection
+              as the key vault host.
+
+          * - ``keyVaultNamespace``
+
+            - String
+
+            - *(Required)* The full namespace of the key vault collection.
+
+          * - ``kmsProvider``
+
+            - Document
+
+            - *(Required)* The Key Management Service (KMS) used by
+              client-side field level encryption for managing a Customer
+              Master Key (CMK).
+
+          * - ``schemaMap``
+
+            - Document
+
+            - *(Optional)* The automatic client-side field level encryption
+              rules specified using the JSON schema Draft 4 standard syntax
+              and encryption-specific keywords.
+
+          * - ``bypassAutoEncryption``
+
+            - Boolean
+
+            - *(Optional)* Specify ``true`` to bypass automatic client-side
+              field level encryption rules and perform explicit (manual)
+              per-field encryption.
+
    * - :method:`Mongo.getDB()`
 
      - Returns a database object.
@@ -690,6 +746,80 @@ standalone and replica set deployments.
    * - :method:`db.getFreeMonitoringStatus()`
 
      - Returns the free cloud monitoring status for your deployment.
+
+Client-Side Field Level Encryption Methods
+------------------------------------------
+
+.. note::
+
+   Automatic encryption is available when ``mongosh`` is connected to an
+   Atlas cluster or a freestanding MongoDB Enterprise Server. For details,
+   see :manual:`Automatic Client-Side Field Level Encryption
+   </core/security-automatic-client-side-encryption/>`.
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Method
+
+     - Description
+
+   * - :method:`ClientEncryption.decrypt()`
+
+     - Decrypts the specified ``encryptedValue`` if the current database
+       connection was configured with access to the Key Management Service
+       (KMS) and key vault used to encrypt ``encryptedValue``.
+
+   * - :method:`ClientEncryption.encrypt()`
+
+     - Encrypts the specified value using the specified ``encryptionKeyId``
+       and ``encryptionAlgorithm``.
+
+   * - :method:`getClientEncryption()`
+
+     - Returns the ``ClientEncryption`` object for the current database
+       collection.
+
+   * - :method:`getKeyVault()`
+
+     - Returns the ``KeyVault`` object for the current database connection. 
+
+   * - :method:`KeyVault.addKeyAlternateName()`
+
+     - Adds the ``keyAltName`` to the ``keyAltNames`` array of the data
+       encryption key with the specified UUID.
+
+   * - :method:`KeyVault.createKey()`
+
+     - Adds a data encryption key to the key vault associated to the
+       database connection.
+
+   * - :method:`KeyVault.deleteKey()`
+
+     - Deletes a data encryption key with the specified UUID from the key
+       vault associated to the database connection.
+
+   * - :method:`KeyVault.getKey()`
+
+     - Gets a data encryption key with the specified UUID. The data
+       encryption key must exist in the key vault associated to the
+       database connection.
+
+   * - :method:`KeyVault.getKeyByAltName()`
+
+     - Gets all data encryption keys with the specified ``keyAltName``.
+
+   * - :method:`KeyVault.getKeys()`
+
+     - Returns all data encryption keys stored in the key vault associated
+       to the database connection.
+
+   * - :method:`KeyVault.removeKeyAlternateName()`
+
+     - Removes the specified ``keyAltName`` from the data encryption key
+       with the specified UUID. The data encryption key must exist in the
+       key vault associated to the database connection.
 
 Native Methods
 --------------

--- a/source/reference/methods.txt
+++ b/source/reference/methods.txt
@@ -750,12 +750,20 @@ standalone and replica set deployments.
 Client-Side Field Level Encryption Methods
 ------------------------------------------
 
-.. note::
+.. note:: Limitations
 
-   Automatic encryption is available when ``mongosh`` is connected to an
-   Atlas cluster or a freestanding MongoDB Enterprise Server. For details,
-   see :manual:`Automatic Client-Side Field Level Encryption
+   Automatic encryption is only available when ``mongosh`` is connected
+   to an Atlas cluster or a MongoDB Enterprise Server. For details, see
+   :manual:`Automatic Client-Side Field Level Encryption
    </core/security-automatic-client-side-encryption/>`.
+
+   Automatic encryption is not available with the Homebrew installation
+   of ``mongosh``.
+
+   Field level encryption is only available in the ``mongosh`` binary,
+   and not available in the :compass:`embedded Compass shell </embedded-shell>`. 
+
+
 
 .. list-table::
    :widths: 30 70

--- a/source/reference/methods.txt
+++ b/source/reference/methods.txt
@@ -361,56 +361,50 @@ Connection Methods
      - JavaScript constructor to instantiate a database connection from
        the ``mongo`` shell or from a JavaScript file.
 
-       The :method:`Mongo()` method takes a parameter called
-       ``ClientSideFieldLevelEncryptionOptions`` with the following options:
+       The :method:`Mongo()` method has the following parameters:
 
        .. list-table::
-          :widths: 15 20 40
-          :header-rows: 1
+           :header-rows: 1
+           :widths: 20 20 80
 
-          * - Option
+           * - Parameter
+       
+             - Type
+       
+             - Description
+       
+           * - ``host``
+       
+             - string
+       
+             - *Optional*
+             
+               The connection string for the target database
+               connection.
 
-            - Type
+               If omitted, :method:`Mongo` instantiates a connection to the 
+               localhost interface on the default port ``27017``.
 
-            - Description
+           * - ``ClientSideFieldLevelEncryptionOptions``
+             
+             - Document
 
-          * - ``keyVaultClient``
+             - *Optional* 
+               
+               .. versionadded:: 4.2
 
-            - :method:`Mongo()` connection object
+               Configuration parameters for enabling
+               :manual:`Client-Side Field Level Encryption
+               </core/security-client-side-encryption>`.
 
-            - *(Optional)* The MongoDB cluster hosting the key vault
-              collection. Omit to use the current database connection
-              as the key vault host.
+               ``ClientSideFieldLevelEncryptionOptions`` overrides the
+               existing client-side field level encryption configuration of
+               the database connection. If omitted, :method:`Mongo()`
+               inherits the client-side field level encryption configuration
+               of the current database connection.
 
-          * - ``keyVaultNamespace``
-
-            - String
-
-            - *(Required)* The full namespace of the key vault collection.
-
-          * - ``kmsProvider``
-
-            - Document
-
-            - *(Required)* The Key Management Service (KMS) used by
-              client-side field level encryption for managing a Customer
-              Master Key (CMK).
-
-          * - ``schemaMap``
-
-            - Document
-
-            - *(Optional)* The automatic client-side field level encryption
-              rules specified using the JSON schema Draft 4 standard syntax
-              and encryption-specific keywords.
-
-          * - ``bypassAutoEncryption``
-
-            - Boolean
-
-            - *(Optional)* The flag to bypass automatic client-side
-              field level encryption rules and perform explicit (manual)
-              per-field encryption.
+               For documentation of usage and syntax, see
+               :ref:`ClientSideFieldLevelEncryptionOptions`.
 
    * - :method:`Mongo.getDB()`
 
@@ -752,18 +746,19 @@ Client-Side Field Level Encryption Methods
 
 .. note:: Limitations
 
-   Automatic encryption is only available when ``mongosh`` is connected
-   to an Atlas cluster or a MongoDB Enterprise Server. For details, see
-   :manual:`Automatic Client-Side Field Level Encryption
-   </core/security-automatic-client-side-encryption/>`.
+   - Automatic encryption is only available when ``mongosh`` is connected
+     to an Atlas cluster or a MongoDB Enterprise Server. For details,
+     see :manual:`Automatic Client-Side Field Level Encryption
+     </core/security-automatic-client-side-encryption/>`. The methods
+     listed in this section are used for *manual* encryption, and are
+     supported on non-enterprise servers.
 
-   Automatic encryption is not available with the Homebrew installation
-   of ``mongosh``.
+   - Automatic encryption is not available with the Homebrew installation
+     of ``mongosh``.
 
-   Field level encryption is only available in the ``mongosh`` binary,
-   and not available in the :compass:`embedded Compass shell </embedded-shell>`. 
-
-
+   - Field level encryption is only available in the ``mongosh`` binary,
+     and not available in the :compass:`embedded Compass shell
+     </embedded-shell>`. 
 
 .. list-table::
    :widths: 30 70

--- a/source/reference/methods.txt
+++ b/source/reference/methods.txt
@@ -362,7 +362,7 @@ Connection Methods
        the ``mongo`` shell or from a JavaScript file.
 
        The :method:`Mongo()` method takes a parameter called
-       ``ClientSideFieldLevelEncryptionOptions``, with the following options:
+       ``ClientSideFieldLevelEncryptionOptions`` with the following options:
 
        .. list-table::
           :widths: 15 20 40
@@ -408,7 +408,7 @@ Connection Methods
 
             - Boolean
 
-            - *(Optional)* Specify ``true`` to bypass automatic client-side
+            - *(Optional)* The flag to bypass automatic client-side
               field level encryption rules and perform explicit (manual)
               per-field encryption.
 
@@ -422,7 +422,7 @@ Connection Methods
 
    * - :method:`Mongo.watch()`
 
-     - Opens a :manual:`change stream cursor </change-streams>` for a replica
+     - Opens a :manual:`change stream cursor </changeStreams>` for a replica
        set or a sharded cluster to report on all its non-system collections
        across its databases, with the exception of the ``admin``, ``local``,
        and ``config`` databases.


### PR DESCRIPTION
These updates cover all tickets in the main [FLE ticket](https://jira.mongodb.org/browse/DOCSP-14006) (which has linked subtasks)

Note: We will be adding a new section for Azure / GCP support for FLE (with examples) shortly after this PR. The main purpose of this PR is to add the new FLE methods to the `mongosh` methods page.

Staging:

- [Install docs](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-13918/install/#procedure) (Homebrew notice)
- [mongosh methods](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-13918/reference/methods/)