### PR TITLE
DOCSP-14691 add shell csfle section

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -3,7 +3,7 @@ title = "MongoDB Shell"
 
 intersphinx = ["https://docs.mongodb.com/manual/objects.inv"]
 
-toc_landing_pages = ["/run-commands", "/crud"]
+toc_landing_pages = ["/run-commands", "/crud", "/field-level-encryption"]
 
 [constants]
 

--- a/source/changelog.txt
+++ b/source/changelog.txt
@@ -26,7 +26,7 @@ v0.8.0
 
 New features in this release:
 
-- Support for :ref:`client-side field level encryption <fle-methods-mongosh>`.
+- Support for :doc:`field-level-encryption`.
 
 Bug fixes in this release:
 
@@ -36,7 +36,7 @@ Bug fixes in this release:
 - Pressing the backspace key in the password prompt no longer adds an
   asterisk, and now behaves as expected.
 
-- Running :method:`~UUID()` without a value now generates a random UUID.
+- Running ``UUID()`` without a value now generates a random UUID.
 
 v0.7.7
 ------

--- a/source/field-level-encryption.txt
+++ b/source/field-level-encryption.txt
@@ -1,0 +1,67 @@
+.. _mdb-shell-csfle:
+
+==================================
+Client-Side Field Level Encryption
+==================================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+When working with a `MongoDB Enterprise
+<http://www.mongodb.com/products/mongodb-enterprise-advanced?jmp=docs>`__
+or MongoDB Atlas cluster, you can use ``mongosh`` to configure
+:manual:`Client-Side Field Level Encryption
+</core/security-client-side-encryption>` and connect with encryption
+support. Client-side field level encryption uses data encryption keys
+for supporting encryption and decryption of field values, and stores
+this encryption key material in a Key Management Service (KMS).
+
+``mongosh`` supports the following KMS providers for use with
+client-side field level encryption:
+
+- Amazon Web Services KMS
+- Azure Key Vault
+- Google Cloud Platform KMS
+- Locally Managed Keyfile
+
+Create a Data Encryption Key
+----------------------------
+
+The following procedure uses ``mongosh`` to create a data encryption key
+for use with client-side field level encryption and decryption.
+
+Use the tabs below to select the :abbr:`KMS (Key Management Service)`
+appropriate for your deployment:
+
+.. tabs::
+
+   .. tab:: Amazon KMS
+      :tabid: aws-kms
+
+      .. include:: /includes/steps/aws-kms.rst
+
+   .. tab:: Azure Key Vault
+      :tabid: azure-vault
+      
+      .. include:: /includes/steps/azure-vault.rst
+
+   .. tab:: Google Cloud KMS
+      :tabid: gcp-kms
+
+      .. include:: /includes/steps/gcp-kms.rst
+
+   .. tab:: Local Keyfile
+      :tabid: local-keyfile
+
+      .. include:: /includes/steps/local-keyfile.rst
+
+.. seealso::
+
+   - :ref:`List of field level encryption shell methods <fle-methods-mongosh>`
+   - :manual:`Client-side field level encryption reference
+     </core/security-client-side-encryption>`

--- a/source/includes/fact-getkey-options.rst
+++ b/source/includes/fact-getkey-options.rst
@@ -1,0 +1,9 @@
+If successful, :method:`createKey() <KeyVault.createKey()>` returns
+the :abbr:`UUID (Universally unique identifier)` of the new data
+encryption key. To retrieve the new data encryption key document from
+the key vault, either:
+
+- Use :method:`getKey() <KeyVault.getKey()>` to retrieve the created
+  key by its :abbr:`UUID (Universally unique identifier)`, or
+- Use :method:`getKeyByAltName() <KeyVault.getKeyByAltName()>`  to
+  retrieve the key by its alternate name, if specified.

--- a/source/includes/steps-aws-kms.yaml
+++ b/source/includes/steps-aws-kms.yaml
@@ -1,0 +1,104 @@
+---
+title: "Launch the ``mongosh`` Shell."
+ref: launch-mongosh-shell
+level: 4
+content: |
+
+  Create a ``mongosh`` session without connecting to a running database
+  by using the :option:`--nodb` option:
+
+  .. code-block:: javascript
+
+     mongosh --nodb
+
+---
+title: "Create the Encryption Configuration."
+ref: create-encryption-configuration
+level: 4
+content: |
+
+  Configuring client-side field level encryption for the AWS KMS
+  requires an AWS Access Key ID and its associated Secret Access Key.
+  The AWS Access Key must correspond to an IAM user with all *List* and
+  *Read* permissions for the KMS service.
+  
+  In ``mongosh``, create a new
+  :ref:`ClientSideFieldLevelEncryptionOptions` variable for storing the
+  client-side field level encryption configuration, which contains these
+  credentials:
+
+  .. code-block:: javascript
+
+     var ClientSideFieldLevelEncryptionOptions = {
+       "keyVaultNamespace" : "encryption.__dataKeys",
+       "kmsProviders" : {
+         "aws" : {
+           "accessKeyId" : "YOUR_AWS_ACCESS_KEY_ID",
+           "secretAccessKey" : "YOUR_AWS_SECRET_ACCESS_KEY"
+         }
+       }
+     }
+
+  Fill in the values for ``YOUR_AWS_ACCESS_KEY_ID`` and
+  ``YOUR_AWS_SECRET_ACCESS_KEY`` as appropriate.
+
+---
+title: "Connect with Encryption Support."
+ref: connect-with-encryption
+level: 4
+content: |
+
+  In ``mongosh``, use the :method:`Mongo()<Mongo()>` constructor to
+  establish a database connection to the target cluster. Specify the
+  :ref:`ClientSideFieldLevelEncryptionOptions` document as the second
+  parameter to the :method:`Mongo()<Mongo()>` constructor to configure
+  the connection for client-side field level encryption:
+
+  .. code-block:: javascript
+
+     csfleDatabaseConnection = Mongo(
+       "mongodb://replaceMe.example.net:27017/?replicaSet=myMongoCluster",
+       ClientSideFieldLevelEncryptionOptions
+     )
+
+  Replace the ``replaceMe.example.net`` :ref:`URI <mongodb-uri>` with
+  the connection string for the target cluster.
+
+---
+title: "Create the Key Vault Object."
+ref: create-keyvault-object
+level: 4
+content: |
+
+  Create the ``keyVault`` object using the :method:`getKeyVault()
+  <getKeyVault()>` shell method:
+
+  .. code-block:: javascript
+
+     keyVault = csfleDatabaseConnection.getKeyVault();
+---
+title: "Create the Encryption Key."
+ref: create-encryption-key
+level: 4
+content: |
+
+  Create the data encryption key using the
+  :method:`createKey() <KeyVault.createKey()>` shell method:
+
+  .. code-block:: javascript
+
+     keyVault.createKey(
+       "aws",
+       { region: "regionname", key: "awsarn" }
+     )
+
+  Where:
+  
+  - ``regionname`` is the AWS region you are connecting to, such as
+    ``us-west-2``
+  - ``awsarn`` is the `Amazon Resource Name (ARN)
+    <https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html>`__
+    to the AWS customer master key (CMK).
+
+  .. include:: /includes/fact-getkey-options.rst
+...

--- a/source/includes/steps-azure-vault.yaml
+++ b/source/includes/steps-azure-vault.yaml
@@ -1,0 +1,101 @@
+---
+title: "Launch the ``mongosh`` Shell."
+ref: launch-mongosh-shell
+level: 4
+content: |
+
+  Create a ``mongosh`` session without connecting to a running database
+  by using the :option:`--nodb` option:
+
+  .. code-block:: javascript
+
+     mongosh --nodb
+
+---
+title: "Create the Encryption Configuration."
+ref: create-encryption-configuration
+level: 4
+content: |
+
+  Configuring client-side field level encryption for Azure Key Vault
+  requires a valid Tenant ID, Client ID, and Client Secret.
+  
+  In ``mongosh``, create a new
+  :ref:`ClientSideFieldLevelEncryptionOptions` variable for storing the
+  client-side field level encryption configuration, which contains these
+  credentials:
+
+  .. code-block:: javascript
+
+     var ClientSideFieldLevelEncryptionOptions = {
+       "keyVaultNamespace" : "encryption.__dataKeys",
+       "kmsProviders" : {
+         "azure" : {
+           "tenantId" : "YOUR_TENANT_ID",
+           "clientId" : "YOUR_CLIENT_ID",
+           "clientSecret" : "YOUR_CLIENT_SECRET"
+         }
+       }
+     }
+
+  Fill in the values for ``YOUR_TENANT_ID``, ``YOUR_CLIENT_ID``, and
+  ``YOUR_CLIENT_SECRET`` as appropriate.
+
+---
+title: "Connect with Encryption Support."
+ref: connect-with-encryption
+level: 4
+content: |
+
+  In ``mongosh``, use the :method:`Mongo()<Mongo()>` constructor to
+  establish a database connection to the target cluster. Specify the
+  :ref:`ClientSideFieldLevelEncryptionOptions` document as the second
+  parameter to the :method:`Mongo()<Mongo()>` constructor to configure
+  the connection for client-side field level encryption:
+
+  .. code-block:: javascript
+
+     csfleDatabaseConnection = Mongo(
+       "mongodb://replaceMe.example.net:27017/?replicaSet=myMongoCluster",
+       ClientSideFieldLevelEncryptionOptions
+     )
+
+  Replace the ``replaceMe.example.net`` :ref:`URI <mongodb-uri>` with
+  the connection string for the target cluster.
+
+---
+title: "Create the Key Vault Object."
+ref: create-keyvault-object
+level: 4
+content: |
+
+  Create the ``keyVault`` object using the :method:`getKeyVault()
+  <getKeyVault()>` shell method:
+
+  .. code-block:: javascript
+
+     keyVault = csfleDatabaseConnection.getKeyVault();
+---
+title: "Create the Encryption Key."
+ref: create-encryption-key
+level: 4
+content: |
+
+  Create the data encryption key using the
+  :method:`createKey() <KeyVault.createKey()>` shell method:
+
+  .. code-block:: javascript
+
+     keyVault.createKey(
+       "azure",
+       { keyName: "keyvaultname", keyVaultEndpoint: "endpointname" }
+     )
+
+  Where:
+  
+  - ``keyvaultname`` is the name of your `Azure Key Vault
+    <https://docs.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates#vault-name-and-object-name>`__
+  - ``endpointname`` is the name of the Key Vault Endpoint to use
+
+  .. include:: /includes/fact-getkey-options.rst
+...

--- a/source/includes/steps-gcp-kms.yaml
+++ b/source/includes/steps-gcp-kms.yaml
@@ -1,0 +1,110 @@
+---
+title: "Launch the ``mongosh`` Shell."
+ref: launch-mongosh-shell
+level: 4
+content: |
+
+  Create a ``mongosh`` session without connecting to a running database
+  by using the :option:`--nodb` option:
+
+  .. code-block:: javascript
+
+     mongosh --nodb
+
+---
+title: "Create the Encryption Configuration."
+ref: create-encryption-configuration
+level: 4
+content: |
+
+  Configuring client-side field level encryption for the GCP KMS
+  requires your GCP Email and its associated Private Key.
+  The AWS Access Key must correspond to an IAM user with all *List* and
+  *Read* permissions for the KMS service.
+  
+  In ``mongosh``, create a new
+  :ref:`ClientSideFieldLevelEncryptionOptions` variable for storing the
+  client-side field level encryption configuration, which contains these
+  credentials:
+
+  .. code-block:: javascript
+
+     var ClientSideFieldLevelEncryptionOptions = {
+       "keyVaultNamespace" : "encryption.__dataKeys",
+       "kmsProviders" : {
+         "gcp" : {
+           "email" : "YOUR_GCP_EMAIL",
+           "privateKey" : "YOUR_GCP_PRIVATEKEY"
+         }
+       }
+     }
+
+  Fill in the values for ``YOUR_GCP_EMAIL`` and
+  ``YOUR_GCP_PRIVATEKEY`` as appropriate.
+
+---
+title: "Connect with Encryption Support."
+ref: connect-with-encryption
+level: 4
+content: |
+
+  In ``mongosh``, use the :method:`Mongo()<Mongo()>` constructor to
+  establish a database connection to the target cluster. Specify the
+  :ref:`ClientSideFieldLevelEncryptionOptions` document as the second
+  parameter to the :method:`Mongo()<Mongo()>` constructor to configure
+  the connection for client-side field level encryption:
+
+  .. code-block:: javascript
+
+     csfleDatabaseConnection = Mongo(
+       "mongodb://replaceMe.example.net:27017/?replicaSet=myMongoCluster",
+       ClientSideFieldLevelEncryptionOptions
+     )
+
+  Replace the ``replaceMe.example.net`` :ref:`URI <mongodb-uri>` with
+  the connection string for the target cluster.
+
+---
+title: "Create the Key Vault Object."
+ref: create-keyvault-object
+level: 4
+content: |
+
+  Create the ``keyVault`` object using the :method:`getKeyVault()
+  <getKeyVault()>` shell method:
+
+  .. code-block:: javascript
+
+     keyVault = csfleDatabaseConnection.getKeyVault();
+---
+title: "Create the Encryption Key."
+ref: create-encryption-key
+level: 4
+content: |
+
+  Create the data encryption key using the
+  :method:`createKey() <KeyVault.createKey()>` shell method:
+
+  .. code-block:: javascript
+
+     keyVault.createKey(
+       "gcp",
+       { projectId: "projectid",
+         location: "locationname",
+         keyRing: "keyringname",
+         keyName: "keyname"
+       }
+     )
+
+  Where:
+  
+  - ``projectid`` is the name of your GCP project, such as
+    ``my-project``
+  - ``locationname`` is the location of the KMS keyring, such as
+    ``global``
+  - ``keyringname`` is the name of the KMS keyring, such as
+    ``my-keyring``
+  - ``keyname`` is the name of your key.
+
+  .. include:: /includes/fact-getkey-options.rst
+...

--- a/source/includes/steps-local-keyfile.yaml
+++ b/source/includes/steps-local-keyfile.yaml
@@ -1,0 +1,101 @@
+---
+title: "Launch the ``mongosh`` Shell."
+ref: launch-mongosh-shell
+level: 4
+content: |
+
+  Create a ``mongosh`` session without connecting to a running database
+  by using the :option:`--nodb` option:
+
+  .. code-block:: javascript
+
+     mongosh --nodb
+
+---
+title: "Generate an Encryption Key."
+ref: generate-local-key
+level: 4
+content: |
+
+  To configure client-side field level encryption for a locally managed
+  key, you must specify a base64-encoded 96-byte string with no line
+  breaks. Run the following command in ``mongosh`` to generate a key
+  matching these requirements:
+
+  .. code-block:: javascript
+
+     crypto.randomBytes(96).toString('base64')
+
+  You will need this key in the next step.
+
+---
+title: "Create the Encryption Configuration."
+ref: create-encryption-configuration
+level: 4
+content: |
+
+  In ``mongosh``, create a new
+  :ref:`ClientSideFieldLevelEncryptionOptions` variable for storing the
+  client-side field level encryption configuration, replacing
+  ``MY_LOCAL_KEY`` with the key generated in step 1:
+
+  .. code-block:: javascript
+
+     var ClientSideFieldLevelEncryptionOptions = {
+       "keyVaultNamespace" : "encryption.__dataKeys",
+       "kmsProviders" : {
+         "local" : {
+           "key" : BinData(0, "MY_LOCAL_KEY")
+         }
+       }
+     }
+
+---
+title: "Connect with Encryption Support."
+ref: connect-with-encryption
+level: 4
+content: |
+
+  In ``mongosh``, use the :method:`Mongo()<Mongo()>` constructor to
+  establish a database connection to the target cluster. Specify the
+  :ref:`ClientSideFieldLevelEncryptionOptions` document as the second
+  parameter to the :method:`Mongo()<Mongo()>` constructor to configure
+  the connection for client-side field level encryption:
+
+  .. code-block:: javascript
+
+     csfleDatabaseConnection = Mongo(
+       "mongodb://replaceMe.example.net:27017/?replicaSet=myMongoCluster",
+       ClientSideFieldLevelEncryptionOptions
+     )
+
+---
+title: "Create the Key Vault Object."
+ref: create-keyvault-object
+level: 4
+content: |
+
+  Create the ``keyVault`` object using the :method:`getKeyVault()
+  <getKeyVault()>` shell method:
+
+  .. code-block:: javascript
+
+     keyVault = csfleDatabaseConnection.getKeyVault();
+---
+title: "Create the Encryption Key."
+ref: create-encryption-key
+level: 4
+content: |
+
+  Create the data encryption key using the
+  :method:`createKey() <KeyVault.createKey()>` shell method:
+
+  .. code-block:: javascript
+
+      keyVault.createKey(
+        "local",
+        ["keyAltName"]
+      )
+
+  .. include:: /includes/fact-getkey-options.rst
+...

--- a/source/index.txt
+++ b/source/index.txt
@@ -122,6 +122,7 @@ Learn More
       /connect
       /run-commands
       /write-scripts
+      /field-level-encryption
       /logs
       /reference
       /changelog


### PR DESCRIPTION
This PR adds a new CSFLE landing page, including:
-  Brief CSFLE overview, linking back to Manual
-  New tab layout for all four supported KMS providers:

    1. AWS KMS (previously supported, but undocumented)
    2. Azure Vault (new with 0.8.0)
    3. GCP KMS (new  with 0.8.0)
    4. Local Keystore (previously supported, but undocumented)

 _NOTES_ 
- I don't presently have a way of testing against an active KMS for any of these platforms, so I have provided my best guesses. Please validate if you, the reviewer, have such access!
- Please let me know if I can provide better, more practical example key names / location names / etc. Or if user params should be indicated in a different manner, perhaps with "< exampleText >". I hesitate to use caps or camelcase, supposing that upstream might not support case identically across all three cloud providers.
- This update only adds "Create a Key" instructions (+validate key, at the end). Let me know if we need to add more tasks, such as dealing with AltNames, or removing keys.
- I left off all optional params to these commands, like specifying KeyAltNames, or overriding cloud-provider-specific KMS URLs/ports. Let me know if this is required.

[ [STAGING LINK](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-14691-add-shell-fle-section/field-level-encryption/#client-side-field-level-encryption) ]

Thank you!