### PR TITLE
DOCS-15881 rename .mongorc.js to .mongoshrc.js

### DIFF
--- a/source/reference/options.txt
+++ b/source/reference/options.txt
@@ -37,8 +37,8 @@ General Options
 
 .. option:: --norc
 
-   Prevents the shell from sourcing and evaluating ``~/.mongorc.js`` on
-   startup.
+   Prevents the shell from sourcing and evaluating ``~/.mongoshrc.js``
+   on startup.
 
 .. option:: --version
 

--- a/source/run-commands.txt
+++ b/source/run-commands.txt
@@ -88,20 +88,31 @@ For more documentation of basic MongoDB operations in ``mongosh``, see:
 - :doc:`/crud/delete`
 - :doc:`/reference/methods`
 
-``.mongorc.js`` File
---------------------
+``.mongoshrc.js`` File
+----------------------
 
-When starting, ``mongosh`` checks the user's ``HOME`` directory for a
-JavaScript file named ``.mongorc.js``. If found, ``mongosh`` interprets
-the content of ``.mongorc.js`` before displaying the prompt for the
-first time.
+On startup, ``mongosh`` checks the user's ``HOME`` directory for a
+JavaScript file named ``.mongoshrc.js``. If this file is found,
+``mongosh`` interprets the content of ``.mongoshrc.js`` before
+displaying the prompt for the first time.
 
-If you use the shell to evaluate a JavaScript file or expression, either
-by using the :option:`--eval <mongosh --eval>` option on the command line
-or by specifying :ref:`a .js file to mongosh <mdb-shell-execute-file>`,
-``mongosh`` reads the ``.mongorc.js`` file *after* the
-JavaScript has finished processing. You can prevent ``.mongorc.js`` from
-being loaded by using the :option:`--norc <mongosh --norc>` option.
+If you use the shell to evaluate a JavaScript file or expression,
+either by using the :option:`--eval <mongosh --eval>` option on the
+command line or by specifying
+:ref:`a .js file to mongosh <mdb-shell-execute-file>`, ``mongosh``
+reads the ``.mongoshrc.js`` file *after* the JavaScript has finished
+processing. You can prevent ``.mongoshrc.js`` from being loaded by
+using the :option:`--norc <mongosh --norc>` option.
+
+.. note::
+
+   The legacy :binary:`~bin.mongo` shell used a configuation file
+   called ``.mongorc.js``. If ``mongosh`` detects this file on startup,
+   and ``.mongoshrc.js`` is not present, ``mongosh`` will suggest
+   renaming ``.mongorc.js`` to ``.mongoshrc.js``. 
+
+   The legacy ``.mongorc.js`` file will not be loaded.
+
 
 Terminate a Running Command
 ---------------------------


### PR DESCRIPTION
This updates the existing docs to change .mongorc.js to .mongoshrc.js

# Jira 
https://jira.mongodb.org/browse/DOCSP-15881

# Staging
https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-15881-update-mongorc.js-file-name/run-commands/#.mongoshrc.js-file

https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-15881-update-mongorc.js-file-name/reference/options/#std-option-mongosh.--norc
