### PR TITLE
(DOCSP-16028): Rename Linux packages from mongosh to mongodb-mongosh

### DIFF
--- a/source/includes/steps-install-shell-linux-deb.yaml
+++ b/source/includes/steps-install-shell-linux-deb.yaml
@@ -98,7 +98,7 @@ content: |
 
   .. code-block:: sh
 
-      sudo apt-get install -y mongosh
+      sudo apt-get install -y mongodb-mongosh
   
   Optional. ``apt-get`` will upgrade the packages when a newer version
   becomes available. To prevent unintended upgrades, you can pin the
@@ -106,6 +106,6 @@ content: |
 
   .. code-block:: sh
 
-    echo "mongosh hold" | sudo dpkg --set-selections
+    echo "mongodb-mongosh hold" | sudo dpkg --set-selections
 
 ...

--- a/source/includes/steps-install-shell-linux-deb.yaml
+++ b/source/includes/steps-install-shell-linux-deb.yaml
@@ -99,13 +99,5 @@ content: |
   .. code-block:: sh
 
       sudo apt-get install -y mongodb-mongosh
-  
-  Optional. ``apt-get`` will upgrade the packages when a newer version
-  becomes available. To prevent unintended upgrades, you can pin the
-  package at the currently installed version:
-
-  .. code-block:: sh
-
-    echo "mongodb-mongosh hold" | sudo dpkg --set-selections
 
 ...

--- a/source/includes/steps-install-shell-linux-rpm.yaml
+++ b/source/includes/steps-install-shell-linux-rpm.yaml
@@ -42,5 +42,5 @@ content: |
 
   .. code-block:: sh
 
-    sudo yum install -y mongosh
+    sudo yum install -y mongodb-mongosh
 ...


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/DOCSP-16028

Staged: [Install mongosh](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-16028/install/)

Changes can be found under the "Linux" tab. See both the `.deb` and `.rpm` sub-tabs.