### PR TITLE
(DOCSP-16174): install page fixups

### DIFF
--- a/source/includes/steps-install-shell-base.yaml
+++ b/source/includes/steps-install-shell-base.yaml
@@ -24,16 +24,20 @@ content: |
 
       tar -zxvf mongosh-{+version+}-linux.tgz
 
-   If your web browser automatically extracts the archive as
-   part of the download or you extract the archive without the
-   ``tar`` command, you may need to run the following command to
-   make ``mongosh`` executable:
+   The extracted ``bin`` folder contains two binaries: ``mongosh`` and
+   ``mongocryptd-mongosh``.
+
+   If your web browser automatically extracts the archive as part of the
+   download or you extract the archive without the ``tar`` command,
+   you may need to make the binaries executable. Run the following
+   commands from the directory where you extracted the archive:
 
    .. code-block:: sh
 
-      chmod +x mongosh
+      chmod +x bin/mongosh
+      chmod +x bin/mongocryptd-mongosh
 ---
-title: "Add the ``mongosh`` binary to your ``PATH`` environment
+title: "Add the downloaded binaries to your ``PATH`` environment
    variable."
 ref: add-shell-to-path
 level: 4
@@ -43,18 +47,20 @@ content: |
 
    - Copy the ``mongosh`` binary into a directory listed in your
      ``PATH`` variable, such as ``/usr/local/bin``. Run the following
-     command from the directory containing the ``mongosh`` binary:
+     commands from the directory where you extracted the download file:
 
      .. code-block:: sh
 
        sudo cp mongosh /usr/local/bin/
+       sudo cp mongocryptd-mongosh /usr/local/bin/
 
    - Create a symbolic link to the ``mongosh`` binary from a directory
-     listed in your ``PATH`` variable, such as ``/usr/local/bin``.
-     Run the following command from the directory containing the
-     ``mongosh`` binary:
+     listed in your ``PATH`` variable, such as ``/usr/local/bin``. Run
+     the following commands from the directory where you extracted the
+     download file:
 
      .. code-block:: sh
 
-       sudo ln -s mongosh /usr/local/bin/
+       sudo ln -s bin/mongosh /usr/local/bin/
+       sudo ln -s bin/mongocryptd-mongosh /usr/local/bin/
 ...

--- a/source/includes/steps-install-shell-macos.yaml
+++ b/source/includes/steps-install-shell-macos.yaml
@@ -9,10 +9,30 @@ source:
   ref: download-archive
 ref: download-archive-macos
 ---
-source:
-  file: steps-install-shell-base.yaml
-  ref: extract-archive
-ref: extract-archive-macos
+title: "Extract the files from the downloaded archive."
+ref: extract-zip-macos
+level: 4
+content: |
+
+   Run the following command from the directory containing the
+   ``mongosh`` ``.zip`` archive:
+   
+   .. code-block:: sh
+
+      unzip mongosh-{version}-darwin-x64.zip
+
+   The extracted ``bin`` folder contains two binaries: ``mongosh`` and
+   ``mongocryptd-mongosh``.
+
+   If your web browser automatically extracts the archive as part of the
+   download or you extract the archive without the ``unzip`` command,
+   you may need to make the binaries executable. Run the following
+   commands from the directory where you extracted the archive:
+
+   .. code-block:: sh
+
+      chmod +x bin/mongosh
+      chmod +x bin/mongocryptd-mongosh
 ---
 source:
   file: steps-install-shell-base.yaml

--- a/source/install.txt
+++ b/source/install.txt
@@ -76,11 +76,11 @@ Procedure
 
       .. _macos-install-archive:
 
-      Install from Tarball
-      ~~~~~~~~~~~~~~~~~~~~
+      Install from ``.zip`` File
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-      To manually install ``mongosh`` using a downloaded ``.tgz``
-      tarball:
+      To manually install ``mongosh`` using a downloaded ``.zip``
+      file:
 
       .. include:: /includes/steps/install-shell-macos.rst
 


### PR DESCRIPTION
JIRA: [DOCSP-16174](https://jira.mongodb.org/browse/DOCSP-16174)
Staged: [install mongosh](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-16174/install/)

Summary of changes:

- On macOS, we’re using .zip instead of .tgz, so the filenames and extraction commands need to be adjusted
- The file suggests copying mongosh to e.g. /usr/local/bin – The mongosh-mongocryptd from the package needs to be copied as well, to /usr/local/libexec or /usr/local/bin as well (or generally ../libexec or ./ when seen relative from the mongosh binary itself)

Note: The JIRA ticket also mentions that the “macOS may prevent mongosh from running after installation” seems outdated, but I could not verify this in testing, so leaving this step in the procedure for now.