### PR TITLE
(DOCSP-16177): Add .msi install instructions

### DIFF
--- a/source/includes/steps-install-shell-windows-msi.yaml
+++ b/source/includes/steps-install-shell-windows-msi.yaml
@@ -1,0 +1,23 @@
+---
+source:
+  file: steps-install-shell-base.yaml
+  ref: navigate-dlc
+ref: navigate-dlc-windows
+---
+title: "In the :guilabel:`Platform` dropdown, select
+   :guilabel:`Windows 64-bit (8.1+) (MSI)`"
+ref: windows-msi-platform-select
+level: 4
+---
+title: "Click :guilabel:`Download`."
+ref: windows-msi-download
+level: 4
+---
+title: "Double-click the installer file."
+ref: windows-msi-click-installer
+level: 4
+---
+title: "Follow the prompts to install ``mongosh``."
+ref: windows-msi-follow-prompt
+level: 4
+...

--- a/source/install.txt
+++ b/source/install.txt
@@ -34,12 +34,20 @@ Procedure
    .. tab::
       :tabid: windows
 
-      .. include:: /includes/steps/install-shell-windows.rst
-
       .. note::
 
          On Windows, ``mongosh`` preferences and configuration options
          are stored in the ``%APPDATA%/mongodb/mongosh`` directory.
+
+      Install from MSI
+      ~~~~~~~~~~~~~~~~
+
+      .. include:: /includes/steps/install-shell-windows-msi.rst
+      
+      Install from ``.zip`` File
+      ~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+      .. include:: /includes/steps/install-shell-windows.rst
 
    .. tab::
       :tabid: macos


### PR DESCRIPTION
.msi install was added in v0.13.1

JIRA: [DOCSP-16177](https://jira.mongodb.org/browse/DOCSP-16177)

STAGED: [Installation Docs](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-16177/install/)