### PR TITLE
DOCSP-15687 numeric values stored as int32

### DIFF
--- a/source/index.txt
+++ b/source/index.txt
@@ -113,17 +113,15 @@ Learn More
 
 - :ref:`View Available Methods in the MongoDB Shell <mdb-shell-methods>`
 
-.. class:: hidden
+.. toctree::
+   :titlesonly:
 
-   .. toctree::
-      :titlesonly:
-      
-      /install
-      /connect
-      /run-commands
-      /write-scripts
-      /field-level-encryption
-      /logs
-      /reference
-      /changelog
-      /reference/compatibility
+   /install
+   /connect
+   /run-commands
+   /write-scripts
+   /field-level-encryption
+   /logs
+   /reference
+   /changelog
+   /reference/compatibility

--- a/source/reference/compatibility.txt
+++ b/source/reference/compatibility.txt
@@ -93,3 +93,62 @@ specified for the operation:
 
 In the legacy ``mongo`` shell, these operations use the specified read
 preference.
+
+Numeric Values
+--------------
+
+The legacy ``mongo`` shell stored numerical values as ``doubles`` by
+default. In ``mongosh`` numbers are stored as 32 bit ``int`` types when
+possible or else as ``double``. 
+
+.. warning::
+
+   Data types may be stored inconsistently if you connect to the same
+   collection using both ``mongosh`` and the legacy ``mongo`` shell. 
+
+Consider the ``typeExample`` collection. This collection consists of
+two identical documents, ``{ "a": 1 }``. The first document was created
+in the legacy ``mongo`` shell, the second document was created in
+``mongosh``. 
+
+We can use the :expression:`$type` operator in an aggregation pipeline
+to see the type that was assigned in each shell. 
+
+.. code-block:: javascript
+
+   db.typeExample.aggregate( 
+     [ 
+       {
+          $project: 
+            { 
+              "valueType": 
+                {
+                  "$type": "$a"
+                },
+              "_id": 0
+            }
+       }
+     ]
+   )
+
+In the first document, created in the legacy ``mongo`` shell, the value
+was stored as a ``double``. In the ``mongosh`` document the value was
+stored as type ``int``.
+
+.. code-block:: javascript
+   .. :copyable: false
+
+   [
+     { 
+        valueType: 'double'  // inserted in legacy mongo shell
+     },
+     {
+        valueType: 'int'     // inserted in mongosh
+     }
+   ]
+
+.. seealso::
+
+   For more information on managing types, refer to the
+   :manual:`schema validation overview </core/schema-validation>`.
+

--- a/source/reference/data-types.txt
+++ b/source/reference/data-types.txt
@@ -130,9 +130,10 @@ operation in ``mongosh``:
 NumberLong
 ~~~~~~~~~~
 
-``mongosh`` treats all numbers as floating-point values by default.
-``mongosh`` provides the ``NumberLong()`` wrapper to handle 64-bit
-integers.
+If a number can be converted to a 32-bit ``int``, ``mongosh`` will
+store it in that form. If not, ``mongosh`` defaults to storing the
+number as a ``double``. The ``NumberLong()`` wrapper can convert the
+type to a 64-bit integer.
 
 The ``NumberLong()`` wrapper accepts the long as a string:
 
@@ -200,24 +201,25 @@ to a floating point value, as in the following example:
 NumberInt
 ~~~~~~~~~
 
-``mongosh`` treats all numbers as floating-point values by default.
-``mongosh`` provides the ``NumberInt()`` constructor to explicitly
-specify 32-bit integers.
+If a number can be converted to a 32-bit ``int``, ``mongosh`` will
+store it in that form. If not, ``mongosh`` defaults to storing the
+number as a ``double``. The ``NumberInt()`` constructor can be used to
+explicitly specify 32-bit integers.
 
 .. _shell-type-decimal:
 
 NumberDecimal
 ~~~~~~~~~~~~~
 
-.. versionadded:: 3.4
+If a number can be converted to a 32-bit ``int``, ``mongosh`` will
+store it in that form. If not, ``mongosh`` defaults to storing the
+number as a ``double``. The ``NumberDecimal()`` constructor can be
+used to explicitly specify 128-bit decimal-based floating-point values
+that are capable of emulating decimal rounding with exact precision. 
 
-``mongosh`` treats all numbers as 64-bit floating-point ``double``
-values by default. ``mongosh`` provides the ``NumberDecimal()``
-constructor to explicitly specify 128-bit decimal-based floating-point
-values capable of emulating decimal rounding with exact precision. This
-functionality is intended for applications that handle :manual:`monetary
-data </tutorial/model-monetary-data>`, such as financial, tax, and
-scientific computations. 
+This functionality is intended for applications that handle
+:manual:`monetary data </tutorial/model-monetary-data>`, such as
+financial, tax, and scientific computations. 
 
 The ``decimal`` :manual:`BSON type </reference/bson-types>`
 uses the IEEE 754 decimal128 floating-point numbering format which
@@ -263,7 +265,7 @@ documents in the ``numbers`` collection:
 
    { "_id" : 1, "val" : NumberDecimal( "9.99" ), "description" : "Decimal" }
    { "_id" : 2, "val" : 9.99, "description" : "Double" }
-   { "_id" : 3, "val" : 10, "description" : "Double" }
+   { "_id" : 3, "val" : 10, "description" : "Int" }
    { "_id" : 4, "val" : NumberLong("10"), "description" : "Long" }
    { "_id" : 5, "val" : NumberDecimal( "10.0" ), "description" : "Decimal" }
 
@@ -285,13 +287,13 @@ returned:
      - **{ "_id": 1, "val": NumberDecimal( "9.99" ), "description": "Decimal" }**
 
    * - **{ val: 10 }**
-     - | **{ "_id": 3, "val": 10, "description": "Double" }**
-       | **{ "_id": 4, "val": NumberLong(10), "description": "Long" }**
+     - | **{ "_id": 3, "val": 10, "description": "Int" }**
+       | **{ "_id": 4, "val": 10, "description": "Long" }**
        | **{ "_id": 5, "val": NumberDecimal( "10.0" ), "description": "Decimal" }**
 
    * - **{ val: NumberDecimal( "10" ) }**
-     - | **{ "_id": 3, "val": 10, "description": "Double" }**
-       | **{ "_id": 4, "val": NumberLong(10), "description": "Long" }**
+     - | **{ "_id": 3, "val": 10, "description": "Int" }**
+       | **{ "_id": 4, "val": 10, "description": "Long" }**
        | **{ "_id": 5, "val": NumberDecimal( "10.0" ), "description": "Decimal" }**
 
 
@@ -322,8 +324,8 @@ string alias ``"decimal"`` or ``19``, the numeric code for the
 
 .. _check-types-in-shell:
       
-Check Types in the ``mongo`` Shell
-----------------------------------
+Check Types in the MongoDB Shell, ``mongosh``
+---------------------------------------------
 
 To determine the type of fields, ``mongosh`` provides the ``instanceof``
 and ``typeof`` operators.


### PR DESCRIPTION
This change updates the type information to state that certain numbers are entered in mongosh as int32 rather than double. It also adds a warning that updating the same database with mongo and mongosh may result in data inconsistency.


### JIRA
https://jira.mongodb.org/browse/DOCSP-15687

### STAGING
https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-15687-numeric-values-stored-as-int32/reference/data-types/