### PR TITLE
(DOCSP-16326): Remove mentions of .load

### DIFF
--- a/source/changelog.txt
+++ b/source/changelog.txt
@@ -134,7 +134,7 @@ v0.9.0
 
 New features in this release:
 
-- Support for the :manual:`load() </reference/method/load/>` method.
+- Support for the :method:`load()` method.
 
 - Support for AWS IAM authentication.
 

--- a/source/write-scripts.txt
+++ b/source/write-scripts.txt
@@ -186,7 +186,7 @@ Execute a JavaScript File
 -------------------------
 
 You can execute a ``.js`` file from within the |mdb-shell|
-using the ``.load`` command. 
+using the :method:`load()` method.
 
 .. example::
 
@@ -194,9 +194,9 @@ using the ``.load`` command.
 
    .. code-block:: javascript
 
-      .load myjstest.js
+      load("myjstest.js")
 
-The ``.load`` command accepts relative and absolute paths. If the
+The :method:`load()` method accepts relative and absolute paths. If the
 current working directory of the |mdb-shell| is ``/data/db``,
 and ``myjstest.js`` resides in the ``/data/db/scripts`` directory, then
 the following calls within the |mdb-shell| are equivalent: 
@@ -204,11 +204,11 @@ the following calls within the |mdb-shell| are equivalent:
 .. code-block:: javascript
    :copyable: false
 
-   .load scripts/myjstest.js
-   .load /data/db/scripts/myjstest.js
+   load("scripts/myjstest.js")
+   load("/data/db/scripts/myjstest.js")
 
 .. note::
 
-   There is no search path for the ``.load`` command. If the desired
+   There is no search path for the :method:`load()` method. If the desired
    script is not in the current working directory or the full specified
    path, the |mdb-shell| cannot access the file.


### PR DESCRIPTION
This update removes mention of `.load` and replaces them with the `load()` method.

JIRA: [DOCSP-16326](https://jira.mongodb.org/browse/DOCSP-16326)

STAGED: [Execute a JavaScript File](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-16326/write-scripts/#execute-a-javascript-file)