### PR TITLE
(DOCSP-16373): Remove MongoDB tap step from homebrew install

### DIFF
--- a/source/includes/steps-install-shell-macos-homebrew.yaml
+++ b/source/includes/steps-install-shell-macos-homebrew.yaml
@@ -7,18 +7,6 @@ content: |
    Refer to the `Homebrew <https://brew.sh/>`__ website
    for the steps to install Homebrew on macOS.
 ---
-title: "Tap the MongoDB Homebrew Tap."
-ref: tab-mongodb
-level: 4
-content: |
-
-   Issue the following command from the terminal to tap the official
-   `MongoDB Homebrew Tap <https://github.com/mongodb/homebrew-brew>`__:
-
-   .. code-block:: sh
-
-      brew tap mongodb/brew
----
 title: "Install the ``mongosh`` package."
 ref: install-mongosh-package
 level: 4


### PR DESCRIPTION
JIRA: [DOCSP-16363](https://jira.mongodb.org/browse/DOCSP-16373)

STAGED: [Install mongosh](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-16373/install/) (see macOS tab for Homebrew instructions)