### PR TITLE
DOCSP-16366 update compatability page in mongosh

### DIFF
--- a/source/reference/compatibility.txt
+++ b/source/reference/compatibility.txt
@@ -17,7 +17,7 @@ Deprecated Methods
 ------------------
 
 The following shell methods are deprecated in ``mongosh``. Instead, use
-the methods listed in the :guilabel:`Alternative Methods` column.
+the methods listed in the :guilabel:`Alternative Resources` column.
 
 .. list-table::
    :header-rows: 1
@@ -25,8 +25,11 @@ the methods listed in the :guilabel:`Alternative Methods` column.
    :widths: 10 10
 
    * - Deprecated Method
-     - Alternative Methods
-   
+     - Alternative Resources
+
+   * - ``db.collection.copyTo()``
+     -   Aggregation stage: :pipeline:`$out`
+
    * - ``db.collection.insert()``
      - - :method:`db.collection.insertOne()`
        - :method:`db.collection.insertMany()`
@@ -45,22 +48,36 @@ the methods listed in the :guilabel:`Alternative Methods` column.
        - :method:`db.collection.updateMany()`
        - :method:`db.collection.findOneAndUpdate()`
 
-
    * - ``db.collection.update()``
      - - :method:`db.collection.updateOne()`
        - :method:`db.collection.updateMany()`
        - :method:`db.collection.findOneAndUpdate()`
        - :method:`db.collection.bulkWrite()`
 
+   * - ``Mongo.getSecondaryOk``
+     - :method:`Mongo.getReadPrefMode`
+ 
+   * - ``Mongo.isCausalConsistency``
+     - :method:`Session.getOptions()`
+
+   * - ``Mongo.setSecondaryOk``
+     - :method:`Mongo.setReadPref`
+     
+   * - ``rs.secondaryOk``
+     - No longer required. See 
+       :ref:`Read Operations on a Secondary Node <read-on-secondary-nodes>`.
+
 Read Preference Behavior
 ------------------------
+
+.. _read-on-secondary-nodes:
 
 Read Operations on a Secondary Node
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When using ``mongosh`` to connect directly to a :term:`secondary`
-replica set member, you do not have to explicitly enable secondary reads
-with ``rs.secondaryOk()``.
+replica set member, you do not have to explicitly enable secondary
+reads with ``rs.secondaryOk()``.
 
 You can read from a secondary member if you specify a
 :manual:`read preference </core/read-preference/>` of either:
@@ -100,6 +117,25 @@ Numeric Values
 The legacy ``mongo`` shell stored numerical values as ``doubles`` by
 default. In ``mongosh`` numbers are stored as 32 bit ``int`` types when
 possible or else as ``double``. 
+
+The preferred types for numeric variables are different in MongoDB 
+Shell than the types suggested in the legacy ``mongo`` shell. The types
+in ``mongosh`` better align with the types used by the MongoDB Drivers.
+
+.. list-table::
+   :header-rows: 1
+
+   * - ``mongo`` type
+     - ``mongosh`` type
+
+   * - ``NumberInt``
+     - ``Int32``
+
+   * - ``NumberLong``
+     - ``Long``
+
+   * - ``NumberDecimal``
+     - ``Decimal128``
 
 .. warning::
 


### PR DESCRIPTION
Updates the compatibility page to:
 - suggest alternatives for some removed/deprecated methods
 - provide a comparison chart for types

STAGING: 
https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-16366-upate-compatability-page/reference/compatibility/