### PR TITLE
Remove references to pino and related libraries.

### DIFF
--- a/source/includes/steps-view-logs.yaml
+++ b/source/includes/steps-view-logs.yaml
@@ -49,18 +49,6 @@ content: |
 
            tail -f ~/.mongodb/mongosh/<LogID>_log
 
-        .. tip::
-
-           You can pipe the output to an installed ``ndjson`` pretty
-           printer, such as `pino-colada
-           <https://www.npmjs.com/package/pino-colada>`__ 
-           or `pino-pretty <https://www.npmjs.com/package/pino-pretty>`__
-           to improve readability:
-
-           .. code-block:: sh
-
-              tail -f ~/.mongodb/mongosh/<LogID>_log | pino-colada
-
      .. tab::
         :tabid: Windows
 
@@ -83,17 +71,5 @@ content: |
         .. code-block:: sh
 
            Get-Content %UserProfile%/AppData/Local/mongodb/mongosh/<LogID>_log
-
-        .. tip::
-
-           You can pipe the output to an installed ``ndjson`` pretty
-           printer, such as `pino-colada
-           <https://www.npmjs.com/package/pino-colada>`__ 
-           or `pino-pretty <https://www.npmjs.com/package/pino-pretty>`__
-           to improve readability:
-
-           .. code-block:: sh
-
-              Get-Content %UserProfile%/AppData/Local/mongodb/mongosh/<LogID>_log -Wait | pino-colada
 
 ...

--- a/source/logs.txt
+++ b/source/logs.txt
@@ -15,8 +15,7 @@ Retrieve Shell Logs
 .. include:: /includes/admonitions/fact-mdb-shell-beta.rst
 
 |mdb-shell| stores logs for each session in `ndjson
-<http://ndjson.org/>`__ format using `pino
-<https://github.com/pinojs/pino>`__. 
+<http://ndjson.org/>`__ format. 
 
 You can view or tail the logs for a |mdb-shell| session based on its
 log ID.


### PR DESCRIPTION
Removing references to `pino` and related libraries gives us the freedom to change the logging library in the future while keeping a newline-delimited JSON as the format.