### PR TITLE
(DOCSP-19437): mongosh telemetry

### DIFF
--- a/source/includes/fact-connect-prereqs.rst
+++ b/source/includes/fact-connect-prereqs.rst
@@ -2,7 +2,7 @@ To use the |mdb-shell|, you must have a MongoDB deployment to connect
 to. 
 
 - For a free cloud-hosted deployment, you can use
-  `MongoDB Atlas <https://www.mongodb.com/cloud/atlas?tck=docs_vsce>`__.
+  `MongoDB Atlas <https://www.mongodb.com/cloud/atlas?tck=docs_mongosh>`__.
 
 - To learn how to run a local MongoDB deployment, see
   :manual:`Install MongoDB </installation/>`.

--- a/source/reference/methods.txt
+++ b/source/reference/methods.txt
@@ -1322,6 +1322,32 @@ Sharding Methods
 
      - Associates a range of shard keys with a zone. Supports configuring
        zones in sharded clusters.
+       
+Telemetry Methods
+-----------------
+
+These methods configure whether ``mongosh`` tracks anonymous telemetry
+data. Telemetry is enabled by default.
+
+For more information on what data ``mongosh`` tracks with
+telemetry, see :ref:`telemetry`.
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Method
+
+     - Description
+
+   * - :method:`disableTelemetry()`
+
+     - Disable telemetry for ``mongosh``. 
+
+   * - :method:`enableTelemetry()`
+
+     - Enable telemetry for ``mongosh``.
+
 
 Transaction Methods
 -------------------

--- a/source/run-commands.txt
+++ b/source/run-commands.txt
@@ -167,4 +167,4 @@ with ``Ctrl + L`` and ``console.clear()``.
    
    /crud
    /run-agg-pipelines
-
+   /telemetry

--- a/source/telemetry.txt
+++ b/source/telemetry.txt
@@ -12,9 +12,9 @@ Configure Telemetry Options
    :depth: 1
    :class: singlecol
 
-``mongosh`` collects anonymous and aggregated usage data to improve MongoDB products.
-``mongosh`` collects this information by default, but you can disable
-this data collection at any time.
+``mongosh`` collects anonymous aggregated usage data to improve
+MongoDB products. ``mongosh`` collects this information by default, but
+you can disable this data collection at any time.
 
 What Kind of Data ``mongosh`` Tracks
 ------------------------------------

--- a/source/telemetry.txt
+++ b/source/telemetry.txt
@@ -1,0 +1,89 @@
+.. _telemetry:
+
+===========================
+Configure Telemetry Options
+===========================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+``mongosh`` collects anonymous usage data to improve MongoDB products.
+``mongosh`` collects this information by default, but you can disable
+this data collection at any time.
+
+What Kind of Data ``mongosh`` Tracks
+------------------------------------
+
+``mongosh`` tracks the following data:
+
+- The type of MongoDB ``mongosh`` is connected to. For example,
+  Enterprise Edition, Community Edition, or Atlas Data Lake.
+
+- The methods run in ``mongosh``. ``mongosh`` only tracks the names of
+  the methods, and does not track any arguments supplied to methods.
+
+- Whether users run scripts with ``mongosh``.
+
+- Errors.
+
+``mongosh`` *does not* track:
+
+- IP addresses, hostnames, usernames, or credentials.
+
+- Queries run in ``mongosh``.
+
+- Any data stored in your MongoDB deployment.
+
+- Personal identifiable information.
+
+Toggle Telemetry Collection
+---------------------------
+
+Use the following methods in ``mongosh`` to toggle telemetry data
+collection.
+
+.. method:: disableTelemetry()
+
+   Disable telemetry for ``mongosh``.
+
+   .. code-block:: javascript
+
+      disableTelemetry()
+
+   The command response confirms that telemetry is disabled:
+
+   .. code-block:: javascript
+      :copyable: false
+
+      Telemetry is now disabled.
+
+   .. tip::
+
+      You can also disable telemetry at startup by using the
+      :option:`--eval <--eval>` startup option.
+      
+      The following command starts ``mongosh`` with telemetry disabled:
+
+      .. code-block:: javascript
+
+         mongosh --nodb --eval "disableTelemetry()"
+
+.. method:: enableTelemetry()
+
+   Enable telemetry for ``mongosh``.
+
+   .. code-block:: javascript
+
+      enableTelemetry()
+
+   The command response confirms that telemetry is enabled:
+
+   .. code-block:: javascript
+      :copyable: false
+
+      Telemetry is now enabled.

--- a/source/telemetry.txt
+++ b/source/telemetry.txt
@@ -12,7 +12,7 @@ Configure Telemetry Options
    :depth: 1
    :class: singlecol
 
-``mongosh`` collects anonymous usage data to improve MongoDB products.
+``mongosh`` collects anonymous and aggregated usage data to improve MongoDB products.
 ``mongosh`` collects this information by default, but you can disable
 this data collection at any time.
 

--- a/source/telemetry.txt
+++ b/source/telemetry.txt
@@ -41,6 +41,9 @@ What Kind of Data ``mongosh`` Tracks
 
 - Personal identifiable information.
 
+For more information, see MongoDB's `Privacy Policy
+<https://www.mongodb.com/legal/privacy-policy?tck=docs_mongosh>`__.
+
 Toggle Telemetry Collection
 ---------------------------
 


### PR DESCRIPTION
Hi @addaleax , @mmarcon.

This update adds documentation for telemetry in mongosh. Would you mind taking a look when you have a chance?

JIRA:

https://jira.mongodb.org/browse/DOCSP-19437

STAGING:

[Configure Telemetry](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-19437/telemetry/)

[Telemetry Methods](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-19437/reference/methods/#telemetry-methods)