### PR TITLE
DOCSP-20167 release notes for mongo.getDBs

### DIFF
--- a/source/changelog.txt
+++ b/source/changelog.txt
@@ -352,8 +352,8 @@ New features in this release:
 
 - New connection methods:
 
-  - :method:`Mongo.getDBNames()` Returns a list of databases.
-  - :method:`Mongo.getDBs()` Returns a document with a list of
+  - :method:`Mongo.getDBNames()` returns a list of databases.
+  - :method:`Mongo.getDBs()` returns a document with a list of
     databases and metadata.
 
 v0.12.1

--- a/source/changelog.txt
+++ b/source/changelog.txt
@@ -350,6 +350,12 @@ New features in this release:
 
 - Adds basic support for the ``--apiStrict`` flag.
 
+- New connection methods:
+
+  - :method:`Mongo.getDBNames()` Returns a list of databases.
+  - :method:`Mongo.getDBs()` Returns a document with a list of
+    databases and metadata.
+
 v0.12.1
 -------
 


### PR DESCRIPTION
These notes need to be merged after the main update which is in the docs repo. 

### JIRA
https://jira.mongodb.org/browse/DOCSP-20167
[MONGOSH] release notes for mongo.getDBs mongo.getDBNames

### STAGING
https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-20167-release-notes-mongogetDBs/changelog/#v0.13.1
