### PR TITLE
DOCSP-16135 match server support matrix

### DIFF
--- a/source/includes/steps-install-shell-linux-deb.yaml
+++ b/source/includes/steps-install-shell-linux-deb.yaml
@@ -1,6 +1,3 @@
-:binary:`mongosh` is available as a :abbr:`PPA (Personal Package
-Archive)` for Ubuntu 20.04 (Focal) and Ubuntu 18.04 (Bionic).
-
 title: Import the public key used by the package management system.
 stepnum: 1
 level: 4

--- a/source/includes/steps-install-shell-linux-deb.yaml
+++ b/source/includes/steps-install-shell-linux-deb.yaml
@@ -1,3 +1,6 @@
+:binary:`mongosh` is available as a :abbr:`PPA (Personal Package
+Archive)` for Ubuntu 20.04 (Focal) and Ubuntu 18.04 (Bionic).
+
 title: Import the public key used by the package management system.
 stepnum: 1
 level: 4

--- a/source/install.txt
+++ b/source/install.txt
@@ -108,6 +108,10 @@ Select the appropriate tab for your operating system:
          .. tab:: .deb
             :tabid: deb
 
+            :binary:`mongosh` is available as a :abbr:`PPA (Personal
+            Package Archive)` for Ubuntu 20.04 (Focal) and Ubuntu 18.04
+            (Bionic).
+
             .. include:: /includes/steps/install-shell-linux-deb.rst
 
          .. tab:: .rpm

--- a/source/install.txt
+++ b/source/install.txt
@@ -117,8 +117,8 @@ Select the appropriate tab for your operating system:
          .. tab:: .rpm
             :tabid: rpm
             
-            mongosh is available as ``yum`` package for :abbr:`RHEL
-            Red Hat Enterprise Linux)` and Amazon Linux 2.
+            :binary:`mongosh` is available as ``yum`` package for
+            :abbr:`RHEL Red Hat Enterprise Linux` and Amazon Linux 2.
 
             .. include:: /includes/steps/install-shell-linux-rpm.rst
 

--- a/source/install.txt
+++ b/source/install.txt
@@ -105,7 +105,7 @@ Select the appropriate tab for your operating system:
       - The ``mongocryptd`` binary that is included in the |mdb-shell|
         ``.deb`` package does not work on unsupported Ubuntu platforms
         (16.04 or older). If you must install :binary:`mongosh` on an
-        unsupported Ubuntu platform :manual:`install
+        unsupported Ubuntu platform, :manual:`install
         </reference/security-client-side-encryption-appendix/#installation>` 
         the ``mongocryptd`` binary separately to use its 
         functionality in the |mdb-shell|.

--- a/source/install.txt
+++ b/source/install.txt
@@ -57,21 +57,21 @@ Select the appropriate tab for your operating system:
          `Homebrew Website <https://docs.brew.sh/Installation>`__.
 
       The Homebrew package manager is the recommended installation
-      method for ``mongosh`` on macOS. To learn how to manually install
-      ``mongosh`` from an archive instead, see
+      method for :binary:`mongosh` on macOS. To learn how to manually
+      install :binary:`mongosh` from an archive instead, see
       :ref:`macos-install-archive`.
 
       Considerations
       ``````````````
 
-      ``mongosh`` installed with Homebrew does not support
+      :binary:`mongosh` installed with Homebrew does not support
       :manual:`automatic client-side field level encryption
       </core/security-automatic-client-side-encryption/>`.
 
       Procedure
       `````````
 
-      To install ``mongosh`` with Homebrew:
+      To install :binary:`mongosh` with Homebrew:
 
       .. include:: /includes/steps/install-shell-macos-homebrew.rst
 
@@ -80,7 +80,7 @@ Select the appropriate tab for your operating system:
       Install from ``.zip`` File
       ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-      To manually install ``mongosh`` using a downloaded ``.zip``
+      To manually install :binary:`mongosh` using a downloaded ``.zip``
       file:
 
       .. include:: /includes/steps/install-shell-macos.rst
@@ -91,21 +91,22 @@ Select the appropriate tab for your operating system:
       Considerations for Ubuntu
       ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-      - ``mongosh`` is available as a
+      - :binary:`mongosh` is available as a
         :abbr:`PPA (Personal Package Archive)` for Ubuntu 20.04 (Focal)
-        and Ubuntu 18.04 (Bionic).
+        and Ubuntu 18.04 (Bionic). If you are installing on Ubuntu
+        20.04 (Focal) or Ubuntu 18.04  (Bionic), use the procedure in
+        the ``.deb`` tab.
         
-        - If you are using Ubuntu 20.04 (Focal) or Ubuntu 18.04
-          (Bionic), use the procedure in the ``.deb`` tab.
-        
-        - If you are using Ubuntu 16.04 (Xenial), you must
-          obtain the ``mongosh`` tarball using the procedure in the
-          ``.tgz`` tab.
+      - MongoDB 5.0 removes support for Ubuntu 16.04 (Xenial). If you
+        must use the unsupported Ubuntu 16.04 (Xenial), install the
+        :binary:`mongosh` tarball using the procedure in the ``.tgz``
+        tab.
       
-      - The ``mongocryptd`` binary in the |mdb-shell| ``.deb`` 
-        package does not work on Ubuntu 16.04 or older. On 
-        Ubuntu 16.04 and older systems, you must 
-        :manual:`install </reference/security-client-side-encryption-appendix/#installation>` 
+      - The ``mongocryptd`` binary that is included in the |mdb-shell|
+        ``.deb`` package does not work on unsupported Ubuntu platforms
+        (16.04 or older). If you must install :binary:`mongosh` on an
+        unsupported Ubuntu platform :manual:`install
+        </reference/security-client-side-encryption-appendix/#installation>` 
         the ``mongocryptd`` binary separately to use its 
         functionality in the |mdb-shell|.
 
@@ -144,5 +145,5 @@ Select the appropriate tab for your operating system:
 Next Steps
 ----------
 
-Once you successfully install ``mongosh``, learn how to
+Once you successfully install :binary:`mongosh`, learn how to
 :ref:`connect to your MongoDB deployment <mdb-shell-connect>`.

--- a/source/install.txt
+++ b/source/install.txt
@@ -88,28 +88,6 @@ Select the appropriate tab for your operating system:
    .. tab::
       :tabid: linux
 
-      Considerations for Ubuntu
-      ~~~~~~~~~~~~~~~~~~~~~~~~~
-
-      - :binary:`mongosh` is available as a
-        :abbr:`PPA (Personal Package Archive)` for Ubuntu 20.04 (Focal)
-        and Ubuntu 18.04 (Bionic). If you are installing on Ubuntu
-        20.04 (Focal) or Ubuntu 18.04  (Bionic), use the procedure in
-        the ``.deb`` tab.
-        
-      - MongoDB 5.0 removes support for Ubuntu 16.04 (Xenial). If you
-        must use the unsupported Ubuntu 16.04 (Xenial), install the
-        :binary:`mongosh` tarball using the procedure in the ``.tgz``
-        tab.
-      
-      - The ``mongocryptd`` binary that is included in the |mdb-shell|
-        ``.deb`` package does not work on unsupported Ubuntu platforms
-        (16.04 or older). If you must install :binary:`mongosh` on an
-        unsupported Ubuntu platform, :manual:`install
-        </reference/security-client-side-encryption-appendix/#installation>` 
-        the ``mongocryptd`` binary separately to use its 
-        functionality in the |mdb-shell|.
-
       Procedure
       ~~~~~~~~~
 
@@ -118,7 +96,7 @@ Select the appropriate tab for your operating system:
 
       - To install the ``.deb`` package on Ubuntu 20.04 (Focal), Ubuntu
         18.04 (Bionic), and Debian, click the ``.deb`` tab.
-      
+
       - To install the ``.rpm`` package on
         :abbr:`RHEL (Red Hat Enterprise Linux)` or Amazon Linux 2,
         click the ``.rpm`` tab.

--- a/source/install.txt
+++ b/source/install.txt
@@ -117,6 +117,9 @@ Select the appropriate tab for your operating system:
          .. tab:: .rpm
             :tabid: rpm
             
+            mongosh is available as ``yum`` package for :abbr:`RHEL
+            Red Hat Enterprise Linux)` and Amazon Linux 2.
+
             .. include:: /includes/steps/install-shell-linux-rpm.rst
 
          .. tab:: .tgz


### PR DESCRIPTION
The jira ticket says it is ok to remove the note about mongocryptd. However, there is existing copy about using older platforms and mongosh is supported back to MongoDB 4.0. With that in mind I modified the copy to highlight dropping support for ubuntu 16.04 instead of removing the information entirely. 

### STAGING
https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-16135-matchserver-support-matrix/install/#considerations-for-ubuntu

### JIRA
https://jira.mongodb.org/browse/DOCSP-16135
[MONGOSH] Match server support matrix for OS/arch
