### PR TITLE
(DOCSP-20843): config reset

### DIFF
--- a/source/changelog.txt
+++ b/source/changelog.txt
@@ -20,8 +20,9 @@ v1.2.1
 - :issue:`MONGOSH-1063` - You can now create a global ``monogosh``
   :ref:`configuration file <mongosh-shell-settings>`.
 
-- :issue:`MONGOSH-959` – You can now use the ``config.reset`` method to
-  return to the default configuration settings.
+- :issue:`MONGOSH-959` – You can now use the :ref:`config.reset
+  <example-reset-setting>` method to return to the default configuration
+  settings.
 
 - :issue:`MONGOSH-1133` – ``mongosh`` adds a ``--tlsUseSystemCA``
   option that causes ``mongosh`` to attempt to load system

--- a/source/reference/configure-shell-settings.txt
+++ b/source/reference/configure-shell-settings.txt
@@ -46,6 +46,12 @@ Change the current setting of ``<property>`` to ``<value>``:
 
    config.set( "<property>", <value> )
 
+Reset a ``<property>`` back to its default value:
+
+.. code-block:: javascript
+
+   config.reset( "<property>" )
+
 Supported ``property`` parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -324,3 +330,34 @@ changes. (Note that this stores the most recent input first.)
    db.contacts.find( {"email": "<email>" } )
    config.set( "redactHistory", "remove-redact" )
 
+Reset a Configuration Setting to Its Default Value
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you modify a configuration setting and want to reset it to its
+default value, use ``config.reset( <"property"> )``.
+
+#. Run the following command to set the value of ``historyLength`` to
+   ``2000``:
+
+   .. code-block:: javascript
+
+      config.set("historyLength", 2000)
+
+#. Verify the updated value for ``historyLength``:
+
+   .. code-block:: javascript
+
+      config.get("historyLength")
+
+#. Reset the ``historyLength`` setting back to its default value of
+   ``1000``:
+
+   .. code-block:: javascript
+
+      config.reset("historyLength")
+
+#. Verify the updated value:
+
+   .. code-block:: javascript
+
+      config.get("historyLength")

--- a/source/reference/configure-shell-settings.txt
+++ b/source/reference/configure-shell-settings.txt
@@ -46,7 +46,7 @@ Change the current setting of ``<property>`` to ``<value>``:
 
    config.set( "<property>", <value> )
 
-Reset a ``<property>`` back to its default value:
+Reset a ``<property>`` to its default value:
 
 .. code-block:: javascript
 

--- a/source/reference/configure-shell-settings.txt
+++ b/source/reference/configure-shell-settings.txt
@@ -335,7 +335,7 @@ changes. (Note that this stores the most recent input first.)
 Reset a Configuration Setting to Its Default Value
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you modify a configuration setting and want to reset it to its
+If you modified a configuration setting and want to reset it to its
 default value, use ``config.reset( <"property"> )``.
 
 #. Run the following command to set the value of ``historyLength`` to

--- a/source/reference/configure-shell-settings.txt
+++ b/source/reference/configure-shell-settings.txt
@@ -330,6 +330,8 @@ changes. (Note that this stores the most recent input first.)
    db.contacts.find( {"email": "<email>" } )
    config.set( "redactHistory", "remove-redact" )
 
+.. _example-reset-setting:
+
 Reset a Configuration Setting to Its Default Value
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/reference/configure-shell-settings.txt
+++ b/source/reference/configure-shell-settings.txt
@@ -351,8 +351,7 @@ default value, use ``config.reset( <"property"> )``.
 
       config.get("historyLength")
 
-#. Reset the ``historyLength`` setting back to its default value of
-   ``1000``:
+#. Reset the ``historyLength`` setting to its default value of ``1000``:
 
    .. code-block:: javascript
 


### PR DESCRIPTION
New configuration management method to reset settings to their default values.

Staged:

- [Syntax](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-20843/reference/configure-shell-settings/#syntax)
- [Example](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-20843/reference/configure-shell-settings/#reset-a-configuration-setting-to-its-default-value)