### PR TITLE
DOCSP-21243 retryable writes enabled by default

### DIFF
--- a/source/reference/compatibility.txt
+++ b/source/reference/compatibility.txt
@@ -112,6 +112,14 @@ specified for the operation:
 In the legacy ``mongo`` shell, these operations use the specified read
 preference.
 
+Write Preference Behavior
+-------------------------
+
+:ref:`Retryable writes <retryable-writes` are the default in
+:binary:`mongosh`. Retryable writes were disabled by default in the
+legacy :binary:`mongo` shell. To disable retryable writes, use 
+:option:`--retryWrites=false <mongosh --retryWrites>`.
+
 Numeric Values
 --------------
 

--- a/source/reference/compatibility.txt
+++ b/source/reference/compatibility.txt
@@ -115,7 +115,7 @@ preference.
 Write Preference Behavior
 -------------------------
 
-:ref:`Retryable writes <retryable-writes>` are the default in
+:ref:`Retryable writes <retryable-writes>` are enabled by default in
 :binary:`mongosh`. Retryable writes were disabled by default in the
 legacy :binary:`mongo` shell. To disable retryable writes, use 
 :option:`--retryWrites=false <mongosh --retryWrites>`.

--- a/source/reference/compatibility.txt
+++ b/source/reference/compatibility.txt
@@ -115,7 +115,7 @@ preference.
 Write Preference Behavior
 -------------------------
 
-:ref:`Retryable writes <retryable-writes` are the default in
+:ref:`Retryable writes <retryable-writes>` are the default in
 :binary:`mongosh`. Retryable writes were disabled by default in the
 legacy :binary:`mongo` shell. To disable retryable writes, use 
 :option:`--retryWrites=false <mongosh --retryWrites>`.

--- a/source/reference/options.txt
+++ b/source/reference/options.txt
@@ -453,7 +453,8 @@ Session Options
 .. option:: --retryWrites
 
    Enables :ref:`retryable-writes`. Retryable writes are the default in
-   |mdb-shell|. To disable retryable writes, use
+   :binary:`mongosh`. Retryable writes are disabled by default in the
+   legacy :binary:`mongo` shell. To disable retryable writes, use
    :option:`--retryWrites=false <mongosh --retryWrites>`
 
    For more information on sessions, see :ref:`sessions`.

--- a/source/reference/options.txt
+++ b/source/reference/options.txt
@@ -452,8 +452,9 @@ Session Options
 
 .. option:: --retryWrites
 
-   Enables :manual:`retryable writes </core/retryable-writes/>` as the
-   default for sessions in the |mdb-shell|.
+   Enables :ref:`retryable-writes`. Retryable writes are the default in
+   |mdb-shell|. To disable retryable writes, use
+   :option:`--retryWrites=false <mongosh --retryWrites>`
 
    For more information on sessions, see :ref:`sessions`.
 

--- a/source/reference/options.txt
+++ b/source/reference/options.txt
@@ -452,10 +452,10 @@ Session Options
 
 .. option:: --retryWrites
 
-   Enables :ref:`retryable-writes`. Retryable writes are the default in
-   :binary:`mongosh`. Retryable writes are disabled by default in the
-   legacy :binary:`mongo` shell. To disable retryable writes, use
-   :option:`--retryWrites=false <mongosh --retryWrites>`
+   Enables :ref:`retryable-writes`. Retryable writes are enabled by
+   default in :binary:`mongosh`. Retryable writes are disabled by
+   default in the legacy :binary:`mongo` shell. To disable retryable
+   writes, use :option:`--retryWrites=false <mongosh --retryWrites>`.
 
    For more information on sessions, see :ref:`sessions`.
 


### PR DESCRIPTION
These are updates in the mongosh repo to accompany updates in the server manual repo (DOCSP-21096)

### STAGING
https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-21243-retryable-writes-enabled-by-default/reference/compatibility/#write-preference-behavior

https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-21243-retryable-writes-enabled-by-default/reference/options/#std-option-mongosh.--retryWrites

### JIRA
https://jira.mongodb.org/browse/DOCSP-21243
[MONGOSH] Retryable writes enabled by default
