### PR TITLE
updated - location of mongosh REPL history file

### DIFF
--- a/source/logs.txt
+++ b/source/logs.txt
@@ -49,10 +49,10 @@ history:
      - Path to History File
 
    * - macOS and Linux
-     - ``~/.mongodb/mongosh/.mongosh_repl_history``
+     - ``~/.mongodb/mongosh/mongosh_repl_history``
 
    * - Windows
-     - ``%UserProfile%/.mongodb/mongosh/.mongosh_repl_history``
+     - ``%UserProfile%/.mongodb/mongosh/mongosh_repl_history``
 
 Log Retention
 -------------


### PR DESCRIPTION
Since this change [](https://github.com/mongodb-js/mongosh/commit/5342ba4550218dade7f875b3077fbe849871b746#diff-e7e7c8e71440ba4421a3ddb9a1f1543f8f79e3420550cbb6a287714a3fd9d832) # (https://github.com/mongodb-js/mongosh/commit/5342ba4550218dade7f875b3077fbe849871b746),  mongosh REPL history is not stored as a hidden file.

I've personally checked this only on the latest docker build, but judging from the code, it affects all platforms.