### PR TITLE
DOCSP-22047 clarify edit autoload

### DIFF
--- a/source/reference/editor-mode.txt
+++ b/source/reference/editor-mode.txt
@@ -194,10 +194,11 @@ The ``nano`` editor will open when you run ``edit`` in the
 Editing a Command
 ~~~~~~~~~~~~~~~~~
 
-Use ``edit`` to modify the last edit. 
+Use ``edit`` to start an editing session. If the editor was already
+used in the current console session, the editor opens the last edit. 
 
-This statement was just written in the external editor. Unfortunately,
-it has a syntax error. The highlighted line is missing a comma: 
+The following statement has a syntax error. The highlighted line is
+missing a comma:
 
 .. code-block:: javascript
    :emphasize-lines: 4
@@ -211,8 +212,15 @@ it has a syntax error. The highlighted line is missing a comma:
       { "name": "Paola", "group": "marketing" }
    ] )
 
-Enter ``edit`` without any arguments to re-edit the command. The
-external editor reloads the last edit.
+To run the example:
+
+#. Copy the example code.
+#. Enter ``edit`` to start an editing session. 
+#. Paste the example code into the editor.
+#. Exit the editor. The example code is copied to the command line.
+#. Press ``enter``. :binary:`mongosh` returns an error.  
+#. Enter ``edit`` without any arguments. The external editor reloads
+   the last edit.
 
 .. code-block:: javascript
    :copyable: false

--- a/source/reference/editor-mode.txt
+++ b/source/reference/editor-mode.txt
@@ -212,15 +212,18 @@ missing a comma:
       { "name": "Paola", "group": "marketing" }
    ] )
 
-To run the example:
+To setup the example:
 
 #. Copy the example code.
 #. Enter ``edit`` to start an editing session. 
 #. Paste the example code into the editor.
-#. Exit the editor. The example code is copied to the command line.
-#. Press ``enter``. :binary:`mongosh` returns an error.  
-#. Enter ``edit`` without any arguments. The external editor reloads
-   the last edit.
+#. Exit the editor. 
+#. Press ``enter``.
+
+When you exit the editor, it copies the example code to the command
+line. :binary:`mongosh` returns an error when the code runs.
+
+To reload the example code, enter ``edit`` without any arguments.
 
 .. code-block:: javascript
    :copyable: false

--- a/source/reference/editor-mode.txt
+++ b/source/reference/editor-mode.txt
@@ -212,7 +212,7 @@ missing a comma:
       { "name": "Paola", "group": "marketing" }
    ] )
 
-To setup the example:
+To set up the example:
 
 #. Copy the example code.
 #. Enter ``edit`` to start an editing session. 


### PR DESCRIPTION
### STAGING
https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-22047-clarify-edit-autoload/reference/editor-mode/#editing-a-command

### JIRA
https://jira.mongodb.org/browse/DOCSP-22047
[MONGOSH] Clarify editor autoload

