### PR TITLE
DOCSP-21466 support for CANONICALIZE_HOST_NAME

### DIFF
--- a/source/connect.txt
+++ b/source/connect.txt
@@ -267,14 +267,11 @@ To disconnect from a deployment and exit ``mongosh``, you can:
 Limitations
 -----------
 
-- ``mongosh`` has the following 
-  :manual:`Kerberos authentication </core/kerberos/>` limitations:
-
-  - ``authMechanismProperties=CANONICALIZE_HOST_NAME:true|false`` is not
-    permitted in the connection string. Instead, specify hostname 
-    canonicalization in the connection string with 
-    ``authMechanismProperties=gssapiCanonicalizeHostName:true|false``.
-  - Hostname canonicalization reverse lookup is not supported.
+- :manual:`Kerberos authentication </core/kerberos/>` does not permit
+  ``authMechanismProperties=CANONICALIZE_HOST_NAME:true|false`` in the
+  connection string. Instead, specify hostname canonicalization in the
+  connection string with
+  ``authMechanismProperties=gssapiCanonicalizeHostName:true|false``.
 
 - ``mongosh`` currently only supports the ``zlib``
   :manual:`compressor </core/wiredtiger/#compression>`. The following 

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -269,9 +269,9 @@ Limitations
 
 - :manual:`Kerberos authentication </core/kerberos/>` does not permit
   ``authMechanismProperties=CANONICALIZE_HOST_NAME:true|false`` in the
-  connection string. Instead, specify hostname canonicalization in the
-  connection string with
-  ``authMechanismProperties=gssapiCanonicalizeHostName:true|false``.
+  connection string. Use one of:
+  ``authMechanismProperties=CANONICALIZE_HOST_NAME:forward|forwardAndReverse|none``
+  instead.
 
 - ``mongosh`` currently only supports the ``zlib``
   :manual:`compressor </core/wiredtiger/#compression>`. The following 

--- a/source/reference/options.txt
+++ b/source/reference/options.txt
@@ -419,8 +419,8 @@ Authentication Options
    If :option:`--sspiHostnameCanonicalization 
    <--sspiHostnameCanonicalization>` is set to:
 
-   - ``forwardAndReverse``, ``mongosh`` 1.3.0 adds support to perform a
-     forward DNS lookup and then a reverse lookup.
+   - ``forwardAndReverse``, performs a forward DNS lookup and then a
+     reverse lookup. New in ``mongosh`` 1.3.0.
    - ``forward``, the effect is the same as setting
      ``authMechanismProperties=CANONICALIZE_HOST_NAME:true``.    
    - ``none``, the effect is the same as setting

--- a/source/reference/options.txt
+++ b/source/reference/options.txt
@@ -419,11 +419,12 @@ Authentication Options
    If :option:`--sspiHostnameCanonicalization 
    <--sspiHostnameCanonicalization>` is set to:
 
-   - ``forward``, the effect is the same as setting ``authMechanismProperties=CANONICALIZE_HOST_NAME:true``.    
-   - ``none``, the effect is the same as setting ``authMechanismProperties=CANONICALIZE_HOST_NAME:false``.    
-
-   :option:`--sspiHostnameCanonicalization 
-   <--sspiHostnameCanonicalization>` cannot be set to ``forwardAndReverse``.  
+   - ``forwardAndReverse``, ``mongosh`` 1.3.0 adds support to perform a
+     forward DNS lookup and then a reverse lookup.
+   - ``forward``, the effect is the same as setting
+     ``authMechanismProperties=CANONICALIZE_HOST_NAME:true``.    
+   - ``none``, the effect is the same as setting
+     ``authMechanismProperties=CANONICALIZE_HOST_NAME:false``.    
 
 .. option:: --password <password>, -p <password>
 


### PR DESCRIPTION
STAGING
https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-21466-support-for-CANONICALIZE_HOST_NAME/reference/options/#std-option-mongosh.--sspiHostnameCanonicalization

https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-21466-support-for-CANONICALIZE_HOST_NAME/connect/#limitations

JIRA
https://jira.mongodb.org/browse/DOCSP-21466
[MONGOSH] Add support for CANONICALIZE_HOST_NAME checks in mongosh
