### PR TITLE
Docsp-22855 update CSFLE binary names

### DIFF
--- a/source/includes/steps-install-shell-base.yaml
+++ b/source/includes/steps-install-shell-base.yaml
@@ -51,7 +51,7 @@ content: |
      .. code-block:: sh
 
        sudo cp mongosh /usr/local/bin/
-       sudo cp mongocryptd-mongosh /usr/local/bin/
+       sudo cp mongosh_csfle_v1.so /usr/local/bin/
 
    - Create symbolic links to the ``MongoDB Shell``. Switch to the
      directory where you extracted the files from the ``.tgz`` archive.

--- a/source/includes/steps-install-shell-base.yaml
+++ b/source/includes/steps-install-shell-base.yaml
@@ -35,7 +35,7 @@ content: |
    .. code-block:: sh
 
       chmod +x bin/mongosh
-      chmod +x bin/mongocryptd-mongosh
+      chmod +x bin/mongosh_csfle_v1.dylib
 ---
 title: "Add the downloaded binaries to your ``PATH`` environment
    variable."

--- a/source/includes/steps-install-shell-base.yaml
+++ b/source/includes/steps-install-shell-base.yaml
@@ -35,7 +35,6 @@ content: |
    .. code-block:: sh
 
       chmod +x bin/mongosh
-      chmod +x bin/mongosh_csfle_v1.so
 ---
 title: "Add the downloaded binaries to your ``PATH`` environment
    variable."

--- a/source/includes/steps-install-shell-base.yaml
+++ b/source/includes/steps-install-shell-base.yaml
@@ -35,7 +35,7 @@ content: |
    .. code-block:: sh
 
       chmod +x bin/mongosh
-      chmod +x bin/mongosh_csfle_v1.dylib
+      chmod +x bin/mongosh_csfle_v1.so
 ---
 title: "Add the downloaded binaries to your ``PATH`` environment
    variable."

--- a/source/includes/steps-install-shell-base.yaml
+++ b/source/includes/steps-install-shell-base.yaml
@@ -25,7 +25,7 @@ content: |
       tar -zxvf mongosh-{+version+}-linux-x64.tgz
 
    The extracted ``bin`` folder contains two binaries: ``mongosh`` and
-   ``mongocryptd-mongosh``.
+   ``mongosh_csfle_v1.so``.
 
    If your web browser automatically extracts the archive as part of the
    download or you extract the archive without the ``tar`` command,

--- a/source/includes/steps-install-shell-base.yaml
+++ b/source/includes/steps-install-shell-base.yaml
@@ -51,7 +51,7 @@ content: |
      .. code-block:: sh
 
        sudo cp mongosh /usr/local/bin/
-       sudo cp mongosh_csfle_v1.so /usr/local/bin/
+       sudo cp mongosh_csfle_v1.so /usr/local/lib/
 
    - Create symbolic links to the ``MongoDB Shell``. Switch to the
      directory where you extracted the files from the ``.tgz`` archive.

--- a/source/includes/steps-install-shell-base.yaml
+++ b/source/includes/steps-install-shell-base.yaml
@@ -30,7 +30,7 @@ content: |
    If your web browser automatically extracts the archive as part of the
    download or you extract the archive without the ``tar`` command,
    you may need to make the binary executable. Run the following
-   commands from the directory where you extracted the archive:
+   command from the directory where you extracted the archive:
 
    .. code-block:: sh
 

--- a/source/includes/steps-install-shell-base.yaml
+++ b/source/includes/steps-install-shell-base.yaml
@@ -29,7 +29,7 @@ content: |
 
    If your web browser automatically extracts the archive as part of the
    download or you extract the archive without the ``tar`` command,
-   you may need to make the binaries executable. Run the following
+   you may need to make the binary executable. Run the following
    commands from the directory where you extracted the archive:
 
    .. code-block:: sh

--- a/source/includes/steps-install-shell-macos.yaml
+++ b/source/includes/steps-install-shell-macos.yaml
@@ -26,7 +26,7 @@ content: |
 
    If your web browser automatically extracts the archive as part of the
    download or you extract the archive without the ``unzip`` command,
-   you may need to make the binaries executable. Run the following
+   you may need to make the binary executable. Run the following
    commands from the directory where you extracted the archive:
 
    .. code-block:: sh

--- a/source/includes/steps-install-shell-macos.yaml
+++ b/source/includes/steps-install-shell-macos.yaml
@@ -32,7 +32,7 @@ content: |
    .. code-block:: sh
 
       chmod +x bin/mongosh
-      chmod +x bin/mongocryptd-mongosh
+      chmod +x bin/mongosh_csfle_v1.dylib
 ---
 source:
   file: steps-install-shell-base.yaml

--- a/source/includes/steps-install-shell-macos.yaml
+++ b/source/includes/steps-install-shell-macos.yaml
@@ -32,7 +32,6 @@ content: |
    .. code-block:: sh
 
       chmod +x bin/mongosh
-      chmod +x bin/mongosh_csfle_v1.dylib
 ---
 source:
   file: steps-install-shell-base.yaml

--- a/source/includes/steps-install-shell-macos.yaml
+++ b/source/includes/steps-install-shell-macos.yaml
@@ -22,7 +22,7 @@ content: |
       unzip mongosh-{+version+}-darwin-x64.zip
 
    The extracted ``bin`` folder contains two binaries: ``mongosh`` and
-   ``mongocryptd-mongosh``.
+   ``mongosh_csfle_v1.dylib``.
 
    If your web browser automatically extracts the archive as part of the
    download or you extract the archive without the ``unzip`` command,

--- a/source/includes/steps-install-shell-macos.yaml
+++ b/source/includes/steps-install-shell-macos.yaml
@@ -27,7 +27,7 @@ content: |
    If your web browser automatically extracts the archive as part of the
    download or you extract the archive without the ``unzip`` command,
    you may need to make the binary executable. Run the following
-   commands from the directory where you extracted the archive:
+   command from the directory where you extracted the archive:
 
    .. code-block:: sh
 

--- a/source/reference/methods.txt
+++ b/source/reference/methods.txt
@@ -136,7 +136,7 @@ Bulk Operation Methods
   
      - Adds an insert operation to a bulk operations list.
 
-   * - :method:`Bulk.tojson()`
+   * - :method:`Bulk.toJSON()`
 
      - Returns a JSON document that contains the number of operations and
        batches in the :method:`Bulk()` object.


### PR DESCRIPTION
Description:

Removed the chmod command for install instructions since shared libs dont need +x. Also updated the binary names for the renamed mongosh files which are now "mongosh_csfle_v1.dylib" for macOS and "mongosh_csfle_v1.so" for linux. Also had to update the link reference `:method:Bulk.tojson()` -> `:method:Bulk.toJSON()` as it was causing a build error.

Jira:
https://jira.mongodb.org/browse/DOCSP-22855

Build:
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=628cf0d27cf5397525895d16

Staging:
https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-22855/install/#install-from-.zip-file-1 (macos tab)

https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-22855/install/#procedure-2 (linux tab)

