### PR TITLE
DOCSP-22993-Add-free-monitoring-callout

### DIFF
--- a/source/free-monitoring.txt
+++ b/source/free-monitoring.txt
@@ -20,13 +20,13 @@ MongoDB's free monitoring service.
 
 To enable free monitoring, run the following command: 
 
-.. code-block:: javascript
+.. code-block:: sh
 
    db.enableFreeMonitoring()
 
 To permanently disable this reminder, run the following command: 
 
-.. code-block:: javascript
+.. code-block:: sh
 
    db.disableFreeMonitoring()
 

--- a/source/free-monitoring.txt
+++ b/source/free-monitoring.txt
@@ -1,0 +1,68 @@
+.. _free_monitoring-mongosh:
+
+===============
+Free Monitoring
+===============
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+.. versionadded:: 1.5
+
+When connecting to MongoDB Community Edition clusters
+with ``mongosh`` you will be prompted with instructions on enabling 
+MongoDB's free monitoring service.
+
+To enable free monitoring, run the following command: 
+
+.. code-block:: javascript
+
+   db.enableFreeMonitoring()
+
+To permanently disable this reminder, run the following command: 
+
+.. code-block:: javascript
+
+   db.disableFreeMonitoring()
+
+Monitored Data
+--------------
+
+Free monitoring provides information about your deployment, including:
+
+- Operation Execution Times
+
+- Memory Usage
+
+- CPU Usage
+
+- Operation Counts
+
+The data expires 24 hours after being uploaded.
+
+Monitored Data and Expiration
+-----------------------------
+
+When enabled, the monitored data is uploaded periodically. The
+monitored data expires after 24 hours. That is, you can only access
+monitored data that has been uploaded within the past 24 hours.
+
+If you disable free monitoring and later re-enable free monitoring, you
+can access your previous metrics that have not expired within the past
+24 hours.
+
+Monitoring URL
+--------------
+
+When you enable free monitoring, you are provided with a unique
+URL where you can access your monitored data.
+
+.. important::
+
+   Anyone with whom you share this unique URL can access your monitored
+   data.

--- a/source/free-monitoring.txt
+++ b/source/free-monitoring.txt
@@ -30,4 +30,4 @@ To permanently disable this reminder, run the following command:
    db.disableFreeMonitoring()
 
 For more information on free monitoring see 
-:ref:`free MongoDB cluster monitoring<free-monitoring-mongodb>`.
+:ref:`free MongoDB monitoring <free-monitoring-mongodb>`.

--- a/source/free-monitoring.txt
+++ b/source/free-monitoring.txt
@@ -12,7 +12,7 @@ Free Monitoring
    :depth: 1
    :class: singlecol
 
-.. versionadded:: 1.5
+.. versionadded:: 1.4.1
 
 When connecting to MongoDB Community Edition clusters
 with ``mongosh`` you will be prompted with instructions on enabling 

--- a/source/free-monitoring.txt
+++ b/source/free-monitoring.txt
@@ -1,4 +1,4 @@
-.. _free_monitoring-mongosh:
+.. _free-monitoring-mongosh:
 
 ===============
 Free Monitoring
@@ -14,9 +14,8 @@ Free Monitoring
 
 .. versionadded:: 1.4.1
 
-When connecting to MongoDB Community Edition clusters
-with ``mongosh`` you will be prompted with instructions on enabling 
-MongoDB's free monitoring service.
+``mongosh`` prompts you to enable MongoDB's free monitoring service when 
+you connect to MongoDB Community Edition clusters.
 
 To enable free monitoring, run the following command: 
 
@@ -30,39 +29,5 @@ To permanently disable this reminder, run the following command:
 
    db.disableFreeMonitoring()
 
-Monitored Data
---------------
-
-Free monitoring provides information about your deployment, including:
-
-- Operation Execution Times
-
-- Memory Usage
-
-- CPU Usage
-
-- Operation Counts
-
-The data expires 24 hours after being uploaded.
-
-Monitored Data and Expiration
------------------------------
-
-When enabled, the monitored data is uploaded periodically. The
-monitored data expires after 24 hours. That is, you can only access
-monitored data that has been uploaded within the past 24 hours.
-
-If you disable free monitoring and later re-enable free monitoring, you
-can access your previous metrics that have not expired within the past
-24 hours.
-
-Monitoring URL
---------------
-
-When you enable free monitoring, you are provided with a unique
-URL where you can access your monitored data.
-
-.. important::
-
-   Anyone with whom you share this unique URL can access your monitored
-   data.
+For more information on free monitoring see 
+:ref:`free mongodb monitoring<free-monitoring-mongodb>`.

--- a/source/free-monitoring.txt
+++ b/source/free-monitoring.txt
@@ -15,7 +15,10 @@ Free Monitoring
 .. versionadded:: 1.4.1
 
 ``mongosh`` prompts you to enable MongoDB's free monitoring service when 
-you connect to MongoDB Community Edition clusters.
+you connect to MongoDB Community Edition cluster.
+
+The monitoring service provides information on your deployment such as 
+operation execution times and memory usage.
 
 To enable free monitoring, run the following command: 
 

--- a/source/free-monitoring.txt
+++ b/source/free-monitoring.txt
@@ -30,4 +30,4 @@ To permanently disable this reminder, run the following command:
    db.disableFreeMonitoring()
 
 For more information on free monitoring see 
-:ref:`free mongodb monitoring<free-monitoring-mongodb>`.
+:ref:`free MongoDB cluster monitoring<free-monitoring-mongodb>`.

--- a/source/index.txt
+++ b/source/index.txt
@@ -37,6 +37,15 @@ Once you have installed the |mdb-shell| and added it to your system
 ``PATH``, you can connect to a MongoDB deployment. To learn more, see
 :ref:`mdb-shell-connect`.
 
+Free Monitoring
+---------------
+
+When connecting to MongoDB Community Edition clusters
+with ``mongosh`` you will be prompted with instructions on enabling 
+MongoDB's free monitoring service.
+
+For more details on free monitoring see :ref:`free_monitoring-mongosh`. 
+
 .. _mdb-shell-multi-line:
 
 ``mongosh`` Editor Mode

--- a/source/index.txt
+++ b/source/index.txt
@@ -37,15 +37,6 @@ Once you have installed the |mdb-shell| and added it to your system
 ``PATH``, you can connect to a MongoDB deployment. To learn more, see
 :ref:`mdb-shell-connect`.
 
-Free Monitoring
----------------
-
-When connecting to MongoDB Community Edition clusters
-with ``mongosh`` you will be prompted with instructions on enabling 
-MongoDB's free monitoring service.
-
-For more details on free monitoring see :ref:`free-monitoring-mongosh`. 
-
 .. _mdb-shell-multi-line:
 
 ``mongosh`` Editor Mode

--- a/source/index.txt
+++ b/source/index.txt
@@ -104,6 +104,7 @@ Learn More
 
    /install
    /connect
+   /free-monitoring
    /field-level-encryption
    /logs
    /run-commands

--- a/source/index.txt
+++ b/source/index.txt
@@ -44,7 +44,7 @@ When connecting to MongoDB Community Edition clusters
 with ``mongosh`` you will be prompted with instructions on enabling 
 MongoDB's free monitoring service.
 
-For more details on free monitoring see :ref:`free_monitoring-mongosh`. 
+For more details on free monitoring see :ref:`free-monitoring-mongosh`. 
 
 .. _mdb-shell-multi-line:
 


### PR DESCRIPTION
Description:

Added a new TOC entry to cover connecting to a community MongoDB cluster with MongoSH and a small page covering  how to enable and disable. The bulk of the information will be on the [server manual page](https://www.mongodb.com/docs/manual/administration/free-monitoring/) which is linked in this edit.

The other edit to add the cross repo ref in manual is [here](https://github.com/10gen/docs-mongodb-internal/pull/1207/files).

Jira:

https://jira.mongodb.org/browse/DOCSP-22993

Build:

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=629f97457cf53975258a1d5e

Staging:

https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-22993/#free-monitoring

https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-22993/free-monitoring/#std-label-free_monitoring-mongosh

