### PR TITLE
DOCSP-23864 update server version

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -15,7 +15,7 @@ toc_landing_pages = ["/run-commands",
 [constants]
 
 version = "1.5.1"
-mdb-version = "5.0"
+mdb-version = "6.0"
 pgp-version = "{+mdb-version+}"
 
 [substitutions]


### PR DESCRIPTION
[STAGING](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-23864-update-server-version/install/#import-the-public-key-used-by-the-package-management-system)   Visible on this page


[JIRA](https://jira.mongodb.org/browse/DOCSP-23864)