### PR TITLE
DOCSP-23878 getLastError

### DIFF
--- a/source/reference/methods.txt
+++ b/source/reference/methods.txt
@@ -638,16 +638,6 @@ Database Methods
 
      - Lists all collections and views in the current database.
 
-   * - :method:`db.getLastError()`
-
-     - Checks and returns the status of the last operation. Wraps
-       :dbcommand:`getLastError`.
-
-   * - :method:`db.getLastErrorObj()`
-
-     - Returns the status document for the last operation. Wraps
-       :dbcommand:`getLastError`.
-
    * - :method:`db.getMongo()`
 
      - Returns the current database connection.


### PR DESCRIPTION
[STAGING](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-23878-build-errors-getLastError/reference/methods/)


[JIRA](https://jira.mongodb.org/browse/DOCSP-23878)


Fixes some build errors. See DOCSP-23879 for the remaining errors.