### PR TITLE
DOCSP-24836 adds refs/labels to reference/options.txt 

### DIFF
--- a/source/reference/options.txt
+++ b/source/reference/options.txt
@@ -104,6 +104,8 @@ Connection Options
      the hostname does not match the ``SAN`` (or ``CN``), the
      |mdb-shell| shell fails to connect.
 
+.. _example-connect-mongosh-using-srv:
+
    For :manual:`DNS seedlist connections </reference/connection-string/#dns-seedlist-connection-format/>`, 
       Specify the connection protocol as ``mongodb+srv``, followed by
       the DNS SRV hostname record and any options. The ``authSource``
@@ -126,6 +128,9 @@ Connection Options
    :binary:`~bin.mongos` instance is listening. If
    :option:`--port <--port>` is not
    specified, the |mdb-shell| attempts to connect to port ``27017``.
+
+.. _mongosh-tls:
+.. _mongosh-ssl:
 
 TLS Options
 ~~~~~~~~~~~
@@ -330,6 +335,8 @@ TLS Options
    to use TLS certificates already available to your operating system
    without explicitly specifying those certificates to ``mongosh``.
 
+.. _mongosh-authentication-options:
+
 Authentication Options
 ----------------------
 
@@ -344,6 +351,8 @@ Authentication Options
    :option:`--authenticationDatabase <--authenticationDatabase>`,
    the |mdb-shell| uses the database specified in the connection
    string.
+
+.. _mongosh-authentication-mechanisms:
 
 .. option:: --authenticationMechanism <name>
 
@@ -462,6 +471,8 @@ Session Options
    For more information on sessions, see :ref:`sessions`.
 
 .. disableImplicitSessions
+
+.. _mongosh-client-side-field-level-encryption-options:
 
 Client-Side Field Level Encryption Options
 ------------------------------------------


### PR DESCRIPTION
Adds refs/labels to reference/options.txt that will serve as updated replacements for labels that point to the legacy mongo shell docs.

# STAGING

https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-24836/reference/options/

This PR only adds refs. There should not be any visible changes.

# JIRA

https://jira.mongodb.org/browse/DOCSP-24836

# BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=630694c933823a066bb6d571