### PR TITLE
DOCSP-24855 adds Stable API options

### DIFF
--- a/source/reference/options.txt
+++ b/source/reference/options.txt
@@ -10,36 +10,18 @@ Options
    :depth: 2
    :class: singlecol
 
+.. program:: mongosh
+
 Use the following options to control various aspects of your
 |mdb-shell| connection and behavior.
 
 General Options
 ---------------
 
-.. program:: mongosh
-
 .. option:: --build-info
 
    Returns a JSON-formatted document with information about the
    :binary:`~bin.mongosh` build.
-
-.. option:: --eval <javascript>
-
-   Evaluates a JavaScript expression. You can use a single ``--eval``
-   argument or multiple ``--eval`` arguments together.
-   
-   After ``mongosh`` evaluates the ``--eval`` argument, it prints the
-   results to your command line. If you use multiple ``--eval``
-   statements, ``mongosh`` only prints the results of the last
-   ``--eval``.
-
-   **Example: Format Output**
-
-   .. include:: /includes/examples/ex-eval-output.rst
-
-   **Example: Multiple ``--eval`` Arguments**
-
-   .. include:: /includes/examples/ex-eval-multi.rst
 
 .. option:: --help, -h
 
@@ -75,6 +57,9 @@ General Options
 .. option:: --version
 
    Returns the |mdb-shell| release number.
+
+
+.. _mongosh-connection-options:
 
 Connection Options
 ------------------

--- a/source/reference/options.txt
+++ b/source/reference/options.txt
@@ -10,18 +10,36 @@ Options
    :depth: 2
    :class: singlecol
 
-.. program:: mongosh
-
 Use the following options to control various aspects of your
 |mdb-shell| connection and behavior.
 
 General Options
 ---------------
 
+.. program:: mongosh
+
 .. option:: --build-info
 
    Returns a JSON-formatted document with information about the
    :binary:`~bin.mongosh` build.
+
+.. option:: --eval <javascript>
+
+   Evaluates a JavaScript expression. You can use a single ``--eval``
+   argument or multiple ``--eval`` arguments together.
+   
+   After ``mongosh`` evaluates the ``--eval`` argument, it prints the
+   results to your command line. If you use multiple ``--eval``
+   statements, ``mongosh`` only prints the results of the last
+   ``--eval``.
+
+   **Example: Format Output**
+
+   .. include:: /includes/examples/ex-eval-output.rst
+
+   **Example: Multiple ``--eval`` Arguments**
+
+   .. include:: /includes/examples/ex-eval-multi.rst
 
 .. option:: --help, -h
 
@@ -58,6 +76,31 @@ General Options
 
    Returns the |mdb-shell| release number.
 
+.. _mongosh-stable-api-options:
+
+Stable API Options
+------------------
+
+.. option:: --apiVersion <version number>
+
+   Specifies the :ref:`apiVersion <api-version-desc>`. ``"1"`` is 
+   currently the only supported value.
+
+.. option:: --apiStrict
+
+   Specifies that the server will respond with :ref:`APIStrictError 
+   <api-strict-resp>` if your application uses a command or behavior 
+   outside of the :ref:`Stable API <stable-api>`.
+   
+   If you specify :option:`--apiStrict`, you must also specify
+   :option:`--apiVersion`.
+
+.. option:: --apiDeprecationErrors
+
+   Specifies that the server will respond with :ref:`APIDeprecationError
+   <api-deprecation-resp>` if your application uses a command or behavior 
+   that is deprecated in the specified :ref:`apiVersion 
+   <api-version-desc>`.
 
 .. _mongosh-connection-options:
 

--- a/source/reference/options.txt
+++ b/source/reference/options.txt
@@ -99,8 +99,10 @@ Stable API Options
 
    Specifies that the server will respond with :ref:`APIDeprecationError
    <api-deprecation-resp>` if your application uses a command or behavior 
-   that is deprecated in the specified :ref:`apiVersion 
-   <api-version-desc>`.
+   that is deprecated in the specified ``apiVersion``.
+
+   If you specify :option:`--apiDeprecationErrors`, you must also 
+   specify :option:`--apiVersion`.
 
 .. _mongosh-connection-options:
 


### PR DESCRIPTION
# STAGING

[Stable API Options](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-24855/reference/options/#stable-api-options)

# JIRA

https://jira.mongodb.org/browse/DOCSP-24855