### PR TITLE
DOCSP-25065 adds isInteractive() and quit() to native methods

### DIFF
--- a/source/reference/methods.txt
+++ b/source/reference/methods.txt
@@ -827,6 +827,11 @@ Native Methods
 
      - Description
 
+   * - ``isInteractive()`` 
+
+     - Returns a boolean indicating whether mongosh is running in 
+       interactive or script mode.
+
    * - :manual:`load() </reference/method/load/>`
 
      - Loads and runs a JavaScript file in the shell.
@@ -853,6 +858,10 @@ Native Methods
           > x = "example text"
           > print(x)
           example text
+
+   * - ``quit()``
+
+     - Exits the current shell session.
 
    * - ``sleep()``
     


### PR DESCRIPTION
## STAGING

https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-25065/reference/methods/#native-methods

## JIRA

https://jira.mongodb.org/browse/DOCSP-25065