### PR TITLE
DOCSP-25400 Resolve mongosh build errors for native methods

### DIFF
--- a/source/changelog.txt
+++ b/source/changelog.txt
@@ -675,7 +675,7 @@ v0.9.0
 
 New features in this release:
 
-- Support for the :method:`load()` method.
+- Support for the :ref:`load() <mongosh-native-method-load>` method.
 
 - Support for AWS IAM authentication.
 

--- a/source/reference/methods.txt
+++ b/source/reference/methods.txt
@@ -827,12 +827,22 @@ Native Methods
 
      - Description
 
-   * - ``isInteractive()`` 
+   * - .. _mongosh-native-method-cd:
+
+       ``cd()``
+
+     - Changes the current working directory to the specified path.
+
+   * - .. _mongosh-native-method-isInteractive:
+
+       ``isInteractive()``
 
      - Returns a boolean indicating whether mongosh is running in 
        interactive or script mode.
 
-   * - :manual:`load() </reference/method/load/>`
+   * - .. _mongosh-native-method-load:
+
+       :manual:`load() </reference/method/load/>`
 
      - Loads and runs a JavaScript file in the shell.
 
@@ -845,7 +855,9 @@ Native Methods
        In the legacy shell, you cannot not access the script's file name
        or directory using the ``load()`` method.
 
-   * - ``print()``
+   * - .. _mongosh-native-method-print:  
+
+       ``print()``
 
      - Print the specified text or variable. ``print()`` and ``printjson()``
        are aliases for ``console.log()``.
@@ -859,15 +871,28 @@ Native Methods
           > print(x)
           example text
 
-   * - ``quit()``
+   * - .. _mongosh-native-method-pwd:
 
+       ``pwd()``
+
+     - Returns the current working directory of the active shell session.
+
+   * - .. _mongosh-native-method-quit:
+
+       ``quit()``
+     
      - Exits the current shell session.
 
-   * - ``sleep()``
-    
+   * - .. _mongosh-native-method-sleep: 
+
+       ``sleep()``
+ 
      - Suspends the |mongo| shell for a given period of time.
 
-   * - ``version()``
+
+   * - .. _mongosh-native-method-version:
+
+       ``version()``
     
      - Returns the current version of the ``mongosh`` instance.
 

--- a/source/reference/methods.txt
+++ b/source/reference/methods.txt
@@ -842,7 +842,7 @@ Native Methods
 
    * - .. _mongosh-native-method-load:
 
-       :manual:`load() </reference/method/load/>`
+       ``load()``
 
      - Loads and runs a JavaScript file in the shell.
 

--- a/source/reference/options.txt
+++ b/source/reference/options.txt
@@ -134,7 +134,7 @@ Connection Options
      the hostname does not match the ``SAN`` (or ``CN``), the
      |mdb-shell| shell fails to connect.
 
-.. _example-connect-mongosh-using-srv:
+   .. _example-connect-mongosh-using-srv:
 
    For :manual:`DNS seedlist connections </reference/connection-string/#dns-seedlist-connection-format/>`, 
       Specify the connection protocol as ``mongodb+srv``, followed by

--- a/source/write-scripts.txt
+++ b/source/write-scripts.txt
@@ -29,15 +29,16 @@ Execute a Script from Within mongosh
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can execute a ``.js`` file from within the |mdb-shell|
-using the :method:`load()` method.
+using the :ref:`load() <mongosh-native-method-load>` method.
 
 File Paths
 ``````````
 
-The :method:`load()` method accepts relative and absolute paths. If the
-current working directory of the |mdb-shell| is ``/data/db``, and
-``connect-and-insert.js`` is in the ``/data/db/scripts`` directory, then
-the following calls within the |mdb-shell| are equivalent: 
+The :ref:`load() <mongosh-native-method-load>` method accepts relative 
+and absolute paths. If the current working directory of the |mdb-shell| 
+is ``/data/db``, and ``connect-and-insert.js`` is in the 
+``/data/db/scripts`` directory, then the following calls within the 
+|mdb-shell| are equivalent: 
 
 .. code-block:: javascript
    :copyable: false
@@ -98,7 +99,8 @@ The following example creates and executes a script that:
 
 .. note::
 
-   There is no search path for the :method:`load()` method. If the target
+   There is no search path for the :ref:`load() 
+   <mongosh-native-method-load>` method. If the target
    script is not in the current working directory or the full specified
    path, the |mdb-shell| cannot access the file.
 

--- a/source/write-scripts/require-load-differences.txt
+++ b/source/write-scripts/require-load-differences.txt
@@ -25,7 +25,7 @@ You can use the following types of scripts with ``mongosh``:
 
   - Code entered directly into the REPL.
   - The :ref:`mongoshrc.js <mongoshrc-js>` file.
-  - Code loaded with the :method:`load()` method.
+  - Code loaded with the :ref:`load() <mongosh-native-method-load>` method.
 
 - Node.js scripts, which are any scripts loaded with ``require()``,
   including npm packages. These scripts are always files.
@@ -68,10 +68,10 @@ The type of script determines how you specify file paths with
 .. tip::
 
    To return the current working directory of the shell, run the
-   :method:`pwd()` method from your script.
+   :ref:`pwd() <mongosh-native-method-pwd>` method from your script.
 
-   To change the shell's working directory, use the :method:`cd()`
-   method in your script.
+   To change the shell's working directory, use the :ref:`cd() 
+   <mongosh-native-method-cd>` method in your script.
 
 Load External Code in a ``mongosh`` Script
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## SUMMARY

Addresses build errors related to mongosh native methods.

## JIRA

https://jira.mongodb.org/browse/DOCSP-25400

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=632cc1f39ef0f10115d89010