### PR TITLE
(DOCSP-26624): Fix mongod/mongos formatting

### DIFF
--- a/source/reference/options.txt
+++ b/source/reference/options.txt
@@ -134,7 +134,7 @@ Connection Options
      the hostname does not match the ``SAN`` (or ``CN``), the
      |mdb-shell| shell fails to connect.
 
-.. _example-connect-mongosh-using-srv:
+   .. _example-connect-mongosh-using-srv:
 
    For :manual:`DNS seedlist connections </reference/connection-string/#dns-seedlist-connection-format/>`, 
       Specify the connection protocol as ``mongodb+srv``, followed by

--- a/source/reference/options.txt
+++ b/source/reference/options.txt
@@ -134,7 +134,7 @@ Connection Options
      the hostname does not match the ``SAN`` (or ``CN``), the
      |mdb-shell| shell fails to connect.
 
-   .. _example-connect-mongosh-using-srv:
+.. _example-connect-mongosh-using-srv:
 
    For :manual:`DNS seedlist connections </reference/connection-string/#dns-seedlist-connection-format/>`, 
       Specify the connection protocol as ``mongodb+srv``, followed by
@@ -216,7 +216,7 @@ TLS Options
    Specifies the :file:`.pem` file that contains the root certificate
    chain from the Certificate Authority. This file is used to validate
    the certificate presented by the
-   :binary:`~bin.mongod`/:binary:`~bin.mongos` instance.
+   :binary:`~bin.mongod` / :binary:`~bin.mongos` instance.
 
    Specify the file name of the :file:`.pem` file using relative or
    absolute paths.
@@ -234,7 +234,7 @@ TLS Options
 .. option:: --tlsAllowInvalidHostnames
 
    Disables the validation of the hostnames in the certificate presented
-   by the :binary:`~bin.mongod`/:binary:`~bin.mongos` instance. Allows
+   by the :binary:`~bin.mongod` / :binary:`~bin.mongos` instance. Allows
    the |mdb-shell| to connect to MongoDB instances even if the hostname
    in the server certificates do not match the server's host.
 
@@ -245,7 +245,7 @@ TLS Options
    .. versionadded:: 4.2
 
    Bypasses the validation checks for the certificates presented by the
-   :binary:`~bin.mongod`/:binary:`~bin.mongos` instance and allows
+   :binary:`~bin.mongod` / :binary:`~bin.mongos` instance and allows
    connections to servers that present invalid certificates.
 
    .. note::


### PR DESCRIPTION
## DESCRIPTION

Fixes an issue where the slash would not appear between "mongod" and "mongos" binary links.

## JIRA

https://jira.mongodb.org/browse/DOCSP-26624

## STAGED

Live docs (no slash): https://www.mongodb.com/docs/mongodb-shell/reference/options/#std-option-mongosh.--tlsCAFile

Staging link (issue fixed): https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-26624/reference/options/#std-option-mongosh.--tlsCAFile