### PR TITLE
DOCSP-26805 mongosh 1.6.1 release notes

### DIFF
--- a/source/changelog.txt
+++ b/source/changelog.txt
@@ -20,9 +20,6 @@ v1.6.1
 - :issue:`MONGOSH-1320`: Fixes a startup bug related to Docker and 
   similar environments.
 
-- :issue:`MONGOSH-955`: ``printjson()`` now prints full, untruncated 
-  output.
-
 - :issue:`MONGOSH-1050`: Adds support for the 
   ``convertShardKeyToHashed()`` helper method.
   

--- a/source/changelog.txt
+++ b/source/changelog.txt
@@ -12,6 +12,23 @@ Release Notes
    :depth: 1
    :class: singlecol
 
+v1.6.1
+------
+
+*Released December 1, 2022*
+
+- :issue:`MONGOSH-1320`: Fixes a startup bug related to Docker and 
+  similar environments.
+
+- :issue:`MONGOSH-955`: ``printjson()`` now prints full, untruncated 
+  output.
+
+- :issue:`MONGOSH-1050`: Adds support for the 
+  ``convertShardKeyToHashed()`` helper method.
+  
+`Full release notes available on JIRA
+<https://jira.mongodb.org/secure/ReleaseNote.jspa?projectId=17381&version=34525>`__.
+
 v1.6.0
 ------
 


### PR DESCRIPTION
## STAGING

https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-26805/changelog/#v1.6.1

## JIRA

https://jira.mongodb.org/browse/DOCSP-26805

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=638a31fbed8015c14b367660