### PR TITLE
(DOCSP-13713): Improve layout of connect page

### DIFF
--- a/source/connect.txt
+++ b/source/connect.txt
@@ -148,7 +148,7 @@ To connect to a replica set, perform one of the following actions:
 
      mongosh "mongodb://mongodb0.example.com.local:27017,mongodb1.example.com.local:27017,mongodb2.example.com.local:27017/?replicaSet=replA"
 
-.. note::
+.. note:: directConnection Parameter
 
    ``mongosh`` adds the ``directConnection=true`` query parameter to the
    connection string automatically unless at least one of the following is

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -175,7 +175,8 @@ run the following command:
    - The connection string uses the ``mongodb+srv://`` connection string
      format.
    - The connection string contains a seed list with multiple hosts.
-   - The connection string already contains a `directConnection` parameter.
+   - The connection string already contains a ``directConnection``
+     parameter.
 
    When ``directConnection=true``, all operations are run on the host
    specified in the connection URI.

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -121,7 +121,7 @@ Connect to a Replica Set
 
 To connect to a replica set, perform one of the following actions:
 
-- If you are using the :manual:`DNS Seedlist Connection Format
+- If you use the :manual:`DNS Seedlist Connection Format
   </reference/connection-string/#dns-seedlist-connection-format>`,include
   the ``+srv`` modifier in your connection string.
 

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -110,7 +110,9 @@ database, run the following command:
    mongosh "mongodb://mongodb0.example.com:28015" --username alice --authenticationDatabase admin
    
 To provide a password as part of the connection command instead of using
-the masked prompt, use the :option:`--password <--password>` option.
+the prompt, use the :option:`--password <--password>` option. Use this
+option for programmatic usage of ``mongosh``, like a :driver:`driver
+</>`.
 
 .. seealso::
 

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -64,9 +64,8 @@ To specify a remote host and port, you can use either:
 
 - A :manual:`connection string </reference/connection-string>`.
 
-- The ``--host`` and ``--port`` command-line options. If you do not
-  include the ``--port`` option, ``mongosh`` uses the default port
-  27017.
+- The ``--host`` and ``--port`` command-line options. If you omit the
+  ``--port`` option, ``mongosh`` uses the default port 27017.
 
 For example, the following commands connect to a MongoDB deployment
 running on host ``mongodb0.example.com`` and port 28015:
@@ -177,8 +176,7 @@ replica set named ``replA``:
 Connect Using TLS
 ~~~~~~~~~~~~~~~~~
 
-To connect to a deployment using TLS, perform one of the following
-actions:
+To connect to a deployment using TLS, you can either:
 
 - Use the :manual:`DNS Seedlist Connection Format
   </reference/connection-string/#dns-seedlist-connection-format>`. The
@@ -192,7 +190,7 @@ actions:
 
      mongosh "mongodb+srv://server.example.com/"
 
-- Specify the :option:`--tls <--tls>` option to ``true`` in the connection
+- Set the :option:`--tls <--tls>` option to ``true`` in the connection
   string.
 
   For example, run the following command to enable ``tls`` with a
@@ -215,7 +213,7 @@ Connect to a Specific Database
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To connect to a specific database, specify a database in your
-:manual:`connection string URI path </reference/connection-string/>` If
+:manual:`connection string URI path </reference/connection-string/>`. If
 you do not specify a database in your URI path, you connect to the
 ``test`` database.
 
@@ -231,7 +229,7 @@ Connect to a Different Deployment
 
 If you are already connected to a deployment in the |mdb-shell|, you can
 use the :method:`Mongo()` or :manual:`connect()
-</reference/method/connect/>` method to connect to a different MongoDB
+</reference/method/connect/>` method to connect to a different
 deployment from within the |mdb-shell|.
 
 To learn how to connect to a different deployment using these methods,

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -97,7 +97,8 @@ Connect With Authentication
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To connect to a MongoDB deployment requires authentication, use the
-``--username`` and ``--authenticationDatabase`` command-line options.
+:option:``--username <--username>`` and
+:option:`--authenticationDatabase <--authenticationDatabase>` options.
 ``mongosh`` prompts you for a password, which it hides as you type.
 
 For example, run the following command to connect to a remote MongoDB

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -101,8 +101,8 @@ To connect to a MongoDB deployment requires authentication, use the
 <--authenticationDatabase>` options. ``mongosh`` prompts you for a
 password, which it hides as you type.
 
-For example, run the following command to connect to a remote MongoDB
-deployment and authenticate on the ``admin`` database as user ``alice``:
+For example, run the following command to authenticate on the ``admin``
+database as user ``alice``:
 
 .. code-block:: sh
 

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -87,8 +87,8 @@ running on host ``mongodb0.example.com`` and port 28015:
    </connect-to-cluster/#use-the-connect-dialog-to-connect-to-your-cluster>`
    in the Atlas documentation.
 
-Connection Options
-------------------
+Specify Connection Options
+--------------------------
 
 Specify different connection options to connect to different types of
 deployments.

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -21,12 +21,11 @@ Prerequisites
 .. include:: /includes/fact-connect-prereqs.rst
    
 
-Local MongoDB Instance on Default Port
---------------------------------------
+Local Deployment on Default Port
+--------------------------------
 
-Run ``mongosh`` without any command-line options
-to connect to a MongoDB instance running on your **localhost** with 
-**default port** 27017:
+To connect to a MongoDB deployment running on **localhost** with
+**default port** 27017, run ``mongosh`` without any options:
 
 .. code-block:: sh
 
@@ -38,92 +37,80 @@ This is equivalent to the following command:
 
    mongosh "mongodb://localhost:27017"
 
-Local MongoDB Instance on a Non-Default Port
---------------------------------------------
+Local Deployment on a Non-Default Port
+--------------------------------------
 
 To specify a port to connect to on localhost, you can use either:
 
 - A :manual:`connection string </reference/connection-string>`.
 
-  For example, the following command connects to a MongoDB deployment
-  running on localhost port 28015:
-  
-  .. code-block:: sh
-
-     mongosh "mongodb://localhost:28015"
-
 - The ``--port`` command-line option.
 
-  For example, the following command connects to a MongoDB deployment
-  running on localhost port 28015:
+For example, the following commands connect to a deployment running on
+localhost port 28015:
 
-  .. code-block:: sh
+.. code-block:: sh
 
-     mongosh --port 28015
+   mongosh "mongodb://localhost:28015"
 
-MongoDB Instance on a Remote Host
----------------------------------
+.. code-block:: sh
+
+   mongosh --port 28015
+
+MongoDB Deployment on a Remote Host
+-----------------------------------
 
 To specify a remote host and port, you can use:
 
 - A :manual:`connection string </reference/connection-string>`.
 
-  .. example:: 
-
-     To connect to a MongoDB
-     instance running on a remote host on port 28015:
-
-     .. code-block:: sh
-
-        mongosh "mongodb://mongodb0.example.com:28015"
-
-  .. note:: Connecting to |service|
-  
-     If your remote host is a |service-fullname| cluster, you can copy 
-     your connection string from the |service| UI. To learn more, see 
-     :atlas:`Connect to a Cluster </connect-to-cluster/#use-the-connect-dialog-to-connect-to-your-cluster>`.
-
-- The command-line options ``--host`` and ``--port``. If you do not 
-  include the ``--port`` option, ``mongosh`` uses the **default port** 
+- The command-line options ``--host`` and ``--port``. If you do not
+  include the ``--port`` option, ``mongosh`` uses the default port
   27017.
 
-  .. example:: 
+For example, the following commands connect to a MongoDB deployment
+running on host ``mongodb0.example.com`` and port 28015:
 
-     To connect to a MongoDB
-     instance running on a remote host on port 28015:
+.. code-block:: sh
 
-     .. code-block:: sh
+   mongosh "mongodb://mongodb0.example.com:28015"
 
-        mongosh --host mongodb0.example.com --port 28015
+.. code-block:: sh
+
+   mongosh --host mongodb0.example.com --port 28015
+
+.. note:: Connect to |service-fullname|
+
+   If your remote host is a |service| cluster, you can copy your
+   connection string from the |service| UI. To learn more, see
+   :atlas:`Connect to a Cluster
+   </connect-to-cluster/#use-the-connect-dialog-to-connect-to-your-cluster>`.
 
 Connection Options
 ------------------
 
+The following sections show how to specify connection options for
+different types of deployments.
+
 Connect with Authentication
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To connect to a MongoDB instance requires authentication, use the 
-``--username`` and ``--authenticationDatabase`` command-line options. 
-``mongosh`` prompts you for a password, which it masks as you type.
-  
-.. example:: 
+To connect to a MongoDB deployment requires authentication, use the
+``--username`` and ``--authenticationDatabase`` command-line options.
+``mongosh`` prompts you for a password, which it hides as you type.
 
-   To connect to a remote MongoDB instance and authenticate against 
-   the ``admin`` database as user ``alice``:
+For example, run the following command to connect to a remote MongoDB
+deployment and authenticate on the ``admin`` database as user ``alice``:
 
-   .. code-block:: sh
+.. code-block:: sh
 
-      mongosh "mongodb://mongodb0.example.com:28015" --username alice --authenticationDatabase admin
-
-.. note::
-
-   To provide a password with the command instead of using the masked 
-   prompt, you can use the ``--password`` option.
+   mongosh "mongodb://mongodb0.example.com:28015" --username alice --authenticationDatabase admin
 
 .. seealso::
 
    - :manual:`Enable Access Control </tutorial/enable-authentication/>` 
      to enforce authentication.
+
    - Add :manual:`Database Users </core/security-users/>` 
      to provide authenticated access to a MongoDB instance.
 
@@ -132,15 +119,16 @@ Connect to a Replica Set
 
 To connect to a replica set:
 
-- If you are using the :manual:`DNS Seedlist Connection Format 
-  </reference/connection-string/#dns-seedlist-connection-format>`, you 
-  can include the ``+srv`` modifier in your connection string.
+- If you are using the :manual:`DNS Seedlist Connection Format
+  </reference/connection-string/#dns-seedlist-connection-format>`,include
+  the ``+srv`` modifier in your connection string.
 
-  .. example::
+  For example, run the following command to connect to a replica set on
+  ``server.example.com``:
 
-     .. code-block:: sh
+  .. code-block:: sh
 
-        mongosh "mongodb+srv://server.example.com/"
+     mongosh "mongodb+srv://server.example.com/"
 
   .. note::
      Using the ``+srv`` connection string modifier automatically sets 

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -42,9 +42,9 @@ Connect to a Local Deployment on a Non-Default Port
 
 To specify a port to connect to on localhost, you can use either:
 
-- A :manual:`connection string </reference/connection-string>`.
+- A :manual:`connection string </reference/connection-string>`
 
-- The ``--port`` command-line option.
+- The ``--port`` command-line option
 
 For example, the following commands connect to a deployment running on
 localhost port 28015:

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -130,23 +130,21 @@ To connect to a replica set:
 
      mongosh "mongodb+srv://server.example.com/"
 
-  .. note::
-     Using the ``+srv`` connection string modifier automatically sets 
-     the 
-     :manual:`tls option </reference/connection-string/#urioption.tls>` 
-     to ``true`` for the connection. You can 
-     override this behavior by explicitly setting ``tls`` to ``false``.
+  .. note:: TLS Behavior
+
+     When you use the ``+srv`` connection string modifier, MongoDB
+     automatically sets the :option:`--tls <--tls>` connection option to
+     ``true``. To override this behavior, set ``--tls`` to ``false``.
 
 - You can specify the replica set name and members in the
   :manual:`connection string </reference/connection-string>`.
 
-  .. example::
+  For example, run the following command to connect to a three-member
+  replica set named ``replA``:
 
-     To connect to a three-member replica set named ``replA``:
+  .. code-block:: sh
 
-     .. code-block:: sh
-
-        mongosh "mongodb://mongodb0.example.com.local:27017,mongodb1.example.com.local:27017,mongodb2.example.com.local:27017/?replicaSet=replA"
+     mongosh "mongodb://mongodb0.example.com.local:27017,mongodb1.example.com.local:27017,mongodb2.example.com.local:27017/?replicaSet=replA"
 
 .. note::
 
@@ -158,68 +156,67 @@ To connect to a replica set:
    - The connection string uses the ``mongodb+srv://`` scheme.
    - The connection string contains a seed list with multiple hosts.
 
+   When ``directConnection=true``, all operations are run on the host
+   specified in the connection URI.
+
 Connect using TLS
 ~~~~~~~~~~~~~~~~~
 
-For ``tls`` connections:
+To connect to a deployment using TLS, perform one of the following
+actions:
 
-- If you are using the :manual:`DNS Seedlist Connection Format 
-  </reference/connection-string/#dns-seedlist-connection-format>`, the 
-  ``+srv`` connection string modifier automatically sets
-  the ``tls`` option to ``true`` for the connection:
+- Use the :manual:`DNS Seedlist Connection Format
+  </reference/connection-string/#dns-seedlist-connection-format>`. The
+  ``+srv`` connection string modifier automatically sets the ``tls``
+  option to ``true`` for the connection.
 
-  .. example::
+  For example, run the following command to connect to a DNS
+  seedlist-defined replica set with ``tls`` enabled:
 
-     To connect to a DNS seedlist-defined replica set with ``tls`` 
-     enabled:
+  .. code-block:: sh
 
-     .. code-block:: sh
+     mongosh "mongodb+srv://server.example.com/"
 
-        mongosh "mongodb+srv://server.example.com/"
+- Specify the :option:`--tls <--tls>` option to ``true`` in the connection
+  string.
 
-- You can use the 
-  :manual:`tls option </reference/connection-string/#urioption.tls>` to 
-  set ``tls=true`` in the 
-  :manual:`connection string </reference/connection-string>`:
+  For example, run the following command to enable ``tls`` with a
+  connection string option:
 
-  .. example::
+  .. code-block:: sh
 
-     To enable ``tls`` in the connection string:
+     mongosh "mongodb://mongodb0.example.com:28015/?tls=true"
 
-     .. code-block:: sh
+- Specify the ``--tls`` command-line option.
 
-        mongosh "mongodb://mongodb0.example.com:28015/?tls=true"
+  For example, run the following command to connect to a remote host
+  with ``tls`` enabled:
 
-- You can specify the ``--tls`` command-line option.
-  
-  .. example:: 
-     
-     To connect to a remote host with ``tls`` enabled:
+  .. code-block:: sh
 
-     .. code-block:: sh
-
-        mongosh "mongodb://mongodb0.example.com:28015" --tls
+     mongosh "mongodb://mongodb0.example.com:28015" --tls
 
 Connect to a Specific Database
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To connect to a specific database, specify a database in your
 :manual:`connection string URI path </reference/connection-string/>` If
-you do not specify a database in your URI path, you connect to a database named ``test``.
+you do not specify a database in your URI path, you connect to the
+``test`` database.
 
-.. example::
+For example, run the following command to connect to a database called
+``qa`` on localhost:
 
-  The following connection string URI connects to database ``db1``.
+.. code-block:: sh
 
-  .. code-block:: sh
-
-      mongosh "mongodb://localhost:27017/db1" 
+    mongosh "mongodb://localhost:27017/qa" 
 
 Connect to a Different Deployment
 ---------------------------------
 
-You can use the :method:`Mongo()` or the :manual:`connect()
-</reference/method/connect/>` methods to connect to a different MongoDB
+If you are already connected to a deployment in the |mdb-shell|, you can
+use the :method:`Mongo()` or :manual:`connect()
+</reference/method/connect/>` method to connect to a different MongoDB
 deployment from within the |mdb-shell|.
 
 To learn how to connect to a different deployment using these methods,
@@ -228,17 +225,17 @@ see :ref:`mdb-shell-open-new-connections-in-shell`.
 Verify Current Connection
 -------------------------
 
-Use the :method:`db.getMongo()` method to verify your current database
-connection.
+To verify your current database connection, use the
+:method:`db.getMongo()` method.
 
-The method returns the
-:manual:`connection string URI </reference/connection-string/>` for
-your current connection.
+The method returns the :manual:`connection string URI
+</reference/connection-string/>` for your current connection.
 
 Disconnect from a Deployment
 ----------------------------
 
-To disconnect from a deployment and exit ``mongosh``, you can:
+To disconnect from a deployment and exit ``mongosh``, perform one of the
+following actions:
 
 - Type ``.exit``, ``exit``, or ``exit()``.
 
@@ -251,11 +248,13 @@ To disconnect from a deployment and exit ``mongosh``, you can:
 Limitations
 -----------
 
-- :manual:`Kerberos authentication </core/kerberos/>` does not permit
+- :manual:`Kerberos authentication </core/kerberos/>` does not allow
   ``authMechanismProperties=CANONICALIZE_HOST_NAME:true|false`` in the
-  connection string. Use one of:
-  ``authMechanismProperties=CANONICALIZE_HOST_NAME:forward|forwardAndReverse|none``
-  instead.
+  connection string. Instead, use either:
+  
+  - ``authMechanismProperties=CANONICALIZE_HOST_NAME:forward``
+  - ``authMechanismProperties=CANONICALIZE_HOST_NAME:forwardAndReverse``
+  - ``authMechanismProperties=CANONICALIZE_HOST_NAME:none``
 
 - ``mongosh`` currently only supports the ``zlib``
   :manual:`compressor </core/wiredtiger/#compression>`. The following 

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -41,29 +41,25 @@ This is equivalent to the following command:
 Local MongoDB Instance on a Non-Default Port
 --------------------------------------------
 
-To specify a port to connect to on localhost, you can use:
+To specify a port to connect to on localhost, you can use either:
 
-- A :manual:`connection string </reference/connection-string>`. 
+- A :manual:`connection string </reference/connection-string>`.
 
-  .. example::
+  For example, the following command connects to a MongoDB deployment
+  running on localhost port 28015:
   
-     To connect to a MongoDB instance running on localhost with a 
-     non-default port 28015:
-  
-     .. code-block:: sh
-  
-        mongosh "mongodb://localhost:28015"
+  .. code-block:: sh
 
-- The command-line option ``--port``.
+     mongosh "mongodb://localhost:28015"
 
-  .. example:: 
+- The ``--port`` command-line option.
 
-     To connect to a MongoDB instance running on localhost with a 
-     non-default port 28015:
+  For example, the following command connects to a MongoDB deployment
+  running on localhost port 28015:
 
-     .. code-block:: sh
+  .. code-block:: sh
 
-        mongosh --port 28015
+     mongosh --port 28015
 
 MongoDB Instance on a Remote Host
 ---------------------------------
@@ -279,5 +275,3 @@ Limitations
 
   - ``zstd``
   - ``snappy``
-
-

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -102,8 +102,8 @@ To connect to a MongoDB deployment that requires authentication, use the
 <--authenticationDatabase>` options. ``mongosh`` prompts you for a
 password, which it hides as you type.
 
-For example, run the following command to authenticate on the ``admin``
-database as user ``alice``:
+For example, to authenticate on the ``admin`` database as user
+``alice``, run the following command:
 
 .. code-block:: sh
 
@@ -134,8 +134,8 @@ Option 1: DNS Seedlist Format
 To use the DNS seedlist connection format, include the ``+srv`` modifier
 in your connection string.
 
-For example, run the following command to connect to a replica set on
-``server.example.com``:
+For example, to connect to a replica set on ``server.example.com``, run
+the following command:
 
 .. code-block:: sh
 
@@ -153,8 +153,8 @@ Option 2: Specify Members in Connection String
 You can specify individual replica set members in the
 :manual:`connection string </reference/connection-string>`.
 
-For example, run the following command to connect to a three-member
-replica set named ``replA``:
+For example, to connect to a three-member replica set named ``replA``,
+run the following command:
 
 .. code-block:: sh
 
@@ -184,8 +184,8 @@ To connect to a deployment using TLS, you can either:
   ``+srv`` connection string modifier automatically sets the ``tls``
   option to ``true`` for the connection.
 
-  For example, run the following command to connect to a DNS
-  seedlist-defined replica set with ``tls`` enabled:
+  For example, to connect to a DNS seedlist-defined replica set with
+  ``tls`` enabled, run the following command:
 
   .. code-block:: sh
 
@@ -194,8 +194,8 @@ To connect to a deployment using TLS, you can either:
 - Set the :option:`--tls <--tls>` option to ``true`` in the connection
   string.
 
-  For example, run the following command to enable ``tls`` with a
-  connection string option:
+  For example, to enable ``tls`` with a connection string option, run
+  the following command:
 
   .. code-block:: sh
 
@@ -203,8 +203,8 @@ To connect to a deployment using TLS, you can either:
 
 - Specify the ``--tls`` command-line option.
 
-  For example, run the following command to connect to a remote host
-  with ``tls`` enabled:
+  For example, to connect to a remote host with ``tls`` enabled, run the
+  following command:
 
   .. code-block:: sh
 
@@ -218,8 +218,8 @@ To connect to a specific database, specify a database in your
 you do not specify a database in your URI path, you connect to the
 ``test`` database.
 
-For example, run the following command to connect to a database called
-``qa`` on localhost:
+For example, to connect to a database called ``qa`` on localhost, run the
+following command:
 
 .. code-block:: sh
 

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -42,7 +42,8 @@ Connect to a Local Deployment on a Non-Default Port
 
 To specify a port to connect to on localhost, you can use either:
 
-- A :manual:`connection string </reference/connection-string>`
+- A :manual:`connection string </reference/connection-string>` with the
+  chosen port
 
 - The ``--port`` command-line option
 
@@ -62,7 +63,8 @@ Connect to a Deployment on a Remote Host
 
 To specify a remote host and port, you can use either:
 
-- A :manual:`connection string </reference/connection-string>`.
+- A :manual:`connection string </reference/connection-string>` with the
+  chosen host and port.
 
 - The ``--host`` and ``--port`` command-line options. If you omit the
   ``--port`` option, ``mongosh`` uses the default port 27017.
@@ -121,7 +123,7 @@ Connect to a Replica Set
 To connect to a replica set, you can either: 
 
 - Use the :manual:`DNS Seedlist Connection Format
-  </reference/connection-string/#dns-seedlist-connection-format>`
+  </reference/connection-string/#dns-seedlist-connection-format>`.
 
 - Explicitly specify the replica set name and members in the connection
   string.
@@ -162,8 +164,7 @@ replica set named ``replA``:
 
    ``mongosh`` automatically adds the ``directConnection=true``
    parameter to the connection string, regardless of the connection
-   string format specified, unless at least one of the following is
-   true:
+   string format used, unless at least one of the following is true:
 
    - The ``replicaSet`` query parameter is present in the connection string.
    - The connection string uses the ``mongodb+srv://`` connection string

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -170,6 +170,7 @@ run the following command:
    - The connection string uses the ``mongodb+srv://`` connection string
      format.
    - The connection string contains a seed list with multiple hosts.
+   - The connection string already contains a `directConnection` parameter.
 
    When ``directConnection=true``, all operations are run on the host
    specified in the connection URI.

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -109,9 +109,8 @@ database, run the following command:
 
    mongosh "mongodb://mongodb0.example.com:28015" --username alice --authenticationDatabase admin
    
-To provide a password as part of the connection command, instead of
-using the masked prompt, use the :option:`--password <--password>`
-option.
+To provide a password as part of the connection command instead of using
+the masked prompt, use the :option:`--password <--password>` option.
 
 .. seealso::
 

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -161,7 +161,7 @@ To connect to a replica set, perform one of the following actions:
    When ``directConnection=true``, all operations are run on the host
    specified in the connection URI.
 
-Connect using TLS
+Connect Using TLS
 ~~~~~~~~~~~~~~~~~
 
 To connect to a deployment using TLS, perform one of the following

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -60,11 +60,11 @@ localhost port 28015:
 MongoDB Deployment on a Remote Host
 -----------------------------------
 
-To specify a remote host and port, you can use:
+To specify a remote host and port, you can use either:
 
 - A :manual:`connection string </reference/connection-string>`.
 
-- The command-line options ``--host`` and ``--port``. If you do not
+- The ``--host`` and ``--port`` command-line options. If you do not
   include the ``--port`` option, ``mongosh`` uses the default port
   27017.
 
@@ -84,15 +84,16 @@ running on host ``mongodb0.example.com`` and port 28015:
    If your remote host is a |service| cluster, you can copy your
    connection string from the |service| UI. To learn more, see
    :atlas:`Connect to a Cluster
-   </connect-to-cluster/#use-the-connect-dialog-to-connect-to-your-cluster>`.
+   </connect-to-cluster/#use-the-connect-dialog-to-connect-to-your-cluster>`
+   in the Atlas documentation.
 
 Connection Options
 ------------------
 
-The following sections show how to specify connection options for
-different types of deployments.
+Specify different connection options to connect to different types of
+deployments.
 
-Connect with Authentication
+Connect With Authentication
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To connect to a MongoDB deployment requires authentication, use the
@@ -108,16 +109,16 @@ deployment and authenticate on the ``admin`` database as user ``alice``:
 
 .. seealso::
 
-   - :manual:`Enable Access Control </tutorial/enable-authentication/>` 
-     to enforce authentication.
+   - To enforce authentication on a deployment, see
+     :manual:`Enable Access Control </tutorial/enable-authentication/>`.
 
-   - Add :manual:`Database Users </core/security-users/>` 
-     to provide authenticated access to a MongoDB instance.
+   - To provision access to a MongoDB deployment, see :manual:`Database
+     Users </core/security-users/>`.
 
 Connect to a Replica Set
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-To connect to a replica set:
+To connect to a replica set, perform one of the following actions:
 
 - If you are using the :manual:`DNS Seedlist Connection Format
   </reference/connection-string/#dns-seedlist-connection-format>`,include
@@ -130,7 +131,7 @@ To connect to a replica set:
 
      mongosh "mongodb+srv://server.example.com/"
 
-  .. note:: TLS Behavior
+  .. note:: +srv TLS Behavior
 
      When you use the ``+srv`` connection string modifier, MongoDB
      automatically sets the :option:`--tls <--tls>` connection option to

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -97,9 +97,9 @@ Connect With Authentication
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To connect to a MongoDB deployment requires authentication, use the
-:option:``--username <--username>`` and
-:option:`--authenticationDatabase <--authenticationDatabase>` options.
-``mongosh`` prompts you for a password, which it hides as you type.
+:option:`--username <--username>` and :option:`--authenticationDatabase
+<--authenticationDatabase>` options. ``mongosh`` prompts you for a
+password, which it hides as you type.
 
 For example, run the following command to connect to a remote MongoDB
 deployment and authenticate on the ``admin`` database as user ``alice``:

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -21,8 +21,8 @@ Prerequisites
 .. include:: /includes/fact-connect-prereqs.rst
    
 
-Local Deployment on Default Port
---------------------------------
+Connect to a Local Deployment on the Default Port
+-------------------------------------------------
 
 To connect to a MongoDB deployment running on **localhost** with
 **default port** 27017, run ``mongosh`` without any options:
@@ -37,8 +37,8 @@ This is equivalent to the following command:
 
    mongosh "mongodb://localhost:27017"
 
-Local Deployment on a Non-Default Port
---------------------------------------
+Connect to a Local Deployment on a Non-Default Port
+---------------------------------------------------
 
 To specify a port to connect to on localhost, you can use either:
 
@@ -57,8 +57,8 @@ localhost port 28015:
 
    mongosh --port 28015
 
-MongoDB Deployment on a Remote Host
------------------------------------
+Connect to a Deployment on a Remote Host
+----------------------------------------
 
 To specify a remote host and port, you can use either:
 
@@ -81,7 +81,7 @@ running on host ``mongodb0.example.com`` and port 28015:
 
 .. note:: Connect to |service-fullname|
 
-   If your remote host is a |service| cluster, you can copy your
+   If your remote host is an |service| cluster, you can copy your
    connection string from the |service| UI. To learn more, see
    :atlas:`Connect to a Cluster
    </connect-to-cluster/#use-the-connect-dialog-to-connect-to-your-cluster>`
@@ -96,7 +96,7 @@ deployments.
 Connect With Authentication
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To connect to a MongoDB deployment requires authentication, use the
+To connect to a MongoDB deployment that requires authentication, use the
 :option:`--username <--username>` and :option:`--authenticationDatabase
 <--authenticationDatabase>` options. ``mongosh`` prompts you for a
 password, which it hides as you type.
@@ -119,43 +119,56 @@ database as user ``alice``:
 Connect to a Replica Set
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-To connect to a replica set, perform one of the following actions:
+To connect to a replica set, you can either: 
 
-- If you use the :manual:`DNS Seedlist Connection Format
-  </reference/connection-string/#dns-seedlist-connection-format>`,include
-  the ``+srv`` modifier in your connection string.
+- Use the :manual:`DNS Seedlist Connection Format
+  </reference/connection-string/#dns-seedlist-connection-format>`
 
-  For example, run the following command to connect to a replica set on
-  ``server.example.com``:
+- Explicitly specify the replica set name and members in the connection
+  string.
 
-  .. code-block:: sh
+Option 1: DNS Seedlist Format
+`````````````````````````````
 
-     mongosh "mongodb+srv://server.example.com/"
+To use the DNS seedlist connection format, include the ``+srv`` modifier
+in your connection string.
 
-  .. note:: +srv TLS Behavior
+For example, run the following command to connect to a replica set on
+``server.example.com``:
 
-     When you use the ``+srv`` connection string modifier, MongoDB
-     automatically sets the :option:`--tls <--tls>` connection option to
-     ``true``. To override this behavior, set ``--tls`` to ``false``.
+.. code-block:: sh
 
-- You can specify the replica set name and members in the
-  :manual:`connection string </reference/connection-string>`.
+   mongosh "mongodb+srv://server.example.com/"
 
-  For example, run the following command to connect to a three-member
-  replica set named ``replA``:
+.. note:: +srv TLS Behavior
 
-  .. code-block:: sh
+   When you use the ``+srv`` connection string modifier, MongoDB
+   automatically sets the :option:`--tls <--tls>` connection option to
+   ``true``. To override this behavior, set ``--tls`` to ``false``.
 
-     mongosh "mongodb://mongodb0.example.com.local:27017,mongodb1.example.com.local:27017,mongodb2.example.com.local:27017/?replicaSet=replA"
+Option 2: Specify Members in Connection String
+``````````````````````````````````````````````
 
-.. note:: directConnection Parameter
+You can specify individual replica set members in the
+:manual:`connection string </reference/connection-string>`.
 
-   ``mongosh`` adds the ``directConnection=true`` query parameter to the
-   connection string automatically unless at least one of the following is
+For example, run the following command to connect to a three-member
+replica set named ``replA``:
+
+.. code-block:: sh
+
+   mongosh "mongodb://mongodb0.example.com.local:27017,mongodb1.example.com.local:27017,mongodb2.example.com.local:27017/?replicaSet=replA"
+   
+.. note:: directConnection Parameter Added Automatically
+
+   ``mongosh`` automatically adds the ``directConnection=true``
+   parameter to the connection string, regardless of the connection
+   string format specified, unless at least one of the following is
    true:
 
    - The ``replicaSet`` query parameter is present in the connection string.
-   - The connection string uses the ``mongodb+srv://`` scheme.
+   - The connection string uses the ``mongodb+srv://`` connection string
+     format.
    - The connection string contains a seed list with multiple hosts.
 
    When ``directConnection=true``, all operations are run on the host

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -102,12 +102,16 @@ To connect to a MongoDB deployment that requires authentication, use the
 <--authenticationDatabase>` options. ``mongosh`` prompts you for a
 password, which it hides as you type.
 
-For example, to authenticate on the ``admin`` database as user
-``alice``, run the following command:
+For example, to authenticate as user ``alice`` on the ``admin``
+database, run the following command:
 
 .. code-block:: sh
 
    mongosh "mongodb://mongodb0.example.com:28015" --username alice --authenticationDatabase admin
+   
+To provide a password as part of the connection command, instead of
+using the masked prompt, use the :option:`--password <--password>`
+option.
 
 .. seealso::
 
@@ -162,9 +166,9 @@ run the following command:
    
 .. note:: directConnection Parameter Added Automatically
 
-   ``mongosh`` automatically adds the ``directConnection=true``
-   parameter to the connection string, regardless of the connection
-   string format used, unless at least one of the following is true:
+   When you specify individual replica set members in the connection
+   string, ``mongosh`` automatically adds the ``directConnection=true``
+   parameter, unless at least one of the following is true:
 
    - The ``replicaSet`` query parameter is present in the connection string.
    - The connection string uses the ``mongodb+srv://`` connection string

--- a/source/includes/fact-connect-prereqs.rst
+++ b/source/includes/fact-connect-prereqs.rst
@@ -10,5 +10,5 @@ to.
 Supported MongoDB Versions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You can use the |mdb-shell| to connect to MongoDB version 4.0 or
+You can use the |mdb-shell| to connect to MongoDB version 4.2 or
 greater.


### PR DESCRIPTION
## DESCRIPTION

The goal here is to remove the clunky ``.. example::`` admonitions on this page and replace them with in-line examples. I also cleaned up some of the wording where appropriate.

## STAGING

https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-13713/connect/

## JIRA

https://jira.mongodb.org/browse/DOCSP-13713

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=638a38f2ed8015c14b37d44f