### PR TITLE
(DOCSP-27120): fix mdb version on amazon install instructions

### DIFF
--- a/source/includes/steps-install-shell-linux-rpm.yaml
+++ b/source/includes/steps-install-shell-linux-rpm.yaml
@@ -31,10 +31,12 @@ content: |
 
             You can also download the ``.rpm`` files directly from the
             `MongoDB repository <https://repo.mongodb.org/yum/redhat/>`__.
-            Downloads are organized by Red Hat or CentOS version (e.g.
-            ``8``), then by MongoDB
-            :manual:`release version </reference/versioning>` (e.g.
-            ``{+mdb-version+}``), then by architecture (e.g. ``x86_64``).
+            Downloads are organized by:
+            
+            - Red Hat or CentOS version (for example, ``8``), then
+            - MongoDB :manual:`release version </reference/versioning>`
+              (for example, ``{+mdb-version+}``), then
+            - Architecture (for example, ``x86_64``).
 
         - id: aws2-tab
           name: Amazon Linux 2
@@ -42,19 +44,22 @@ content: |
 
             .. code-block:: shell
 
-               [mongodb-org-5.0]
+               [mongodb-org-{+mdb-version+}]
                name=MongoDB Repository
-               baseurl=https://repo.mongodb.org/yum/amazon/2/mongodb-org/5.0/x86_64/
+               baseurl=https://repo.mongodb.org/yum/amazon/2/mongodb-org/{+mdb-version+}/x86_64/
                gpgcheck=1
                enabled=1
-               gpgkey=https://www.mongodb.org/static/pgp/server-5.0.asc 
+               gpgkey=https://www.mongodb.org/static/pgp/server-{+pgp-version+}.asc 
 
             You can also download the ``.rpm`` files directly from the
-            `MongoDB repository <https://repo.mongodb.org/yum/amazon/>`__.
-            Downloads are organized by Amazon Linux version (e.g.\
-            ``2``), then by MongoDB
-            :manual:`release version </reference/versioning>` (e.g.
-            ``{+mdb-version+}``), then architecture (e.g. ``x86_64``).
+            `MongoDB repository
+            <https://repo.mongodb.org/yum/amazon/>`__. Downloads are
+            organized by:
+            
+            - Amazon Linux version (for example, ``2``), then
+            - MongoDB :manual:`release version </reference/versioning>`
+              (for example, ``{+mdb-version+}``), then
+            - Architecture (for example, ``x86_64``).
 
 ---
 title: Install ``mongosh``.

--- a/source/includes/steps-install-shell-linux-rpm.yaml
+++ b/source/includes/steps-install-shell-linux-rpm.yaml
@@ -34,8 +34,12 @@ content: |
             Downloads are organized in the following order:
             
             1. Red Hat or CentOS version (for example, ``8``)
+
+            #. MongoDB edition (for example, ``mongodb-enterprise``)
+
             #. MongoDB :manual:`release version </reference/versioning>`
                (for example, ``{+mdb-version+}``)
+
             #. Architecture (for example, ``x86_64``)
 
         - id: aws2-tab
@@ -56,10 +60,12 @@ content: |
             <https://repo.mongodb.org/yum/amazon/>`__. Downloads are
             organized in the following order:
             
-            1. Amazon Linux version (for example, ``2``), then
+            1. Amazon Linux version (for example, ``2``)
+
             #. MongoDB :manual:`release version </reference/versioning>`
-               (for example, ``{+mdb-version+}``), then
-            #. Architecture (for example, ``x86_64``).
+               (for example, ``{+mdb-version+}``)
+
+            #. Architecture (for example, ``x86_64``)
 
 ---
 title: Install ``mongosh``.

--- a/source/includes/steps-install-shell-linux-rpm.yaml
+++ b/source/includes/steps-install-shell-linux-rpm.yaml
@@ -31,12 +31,12 @@ content: |
 
             You can also download the ``.rpm`` files directly from the
             `MongoDB repository <https://repo.mongodb.org/yum/redhat/>`__.
-            Downloads are organized by:
+            Downloads are organized in the following order:
             
-            - Red Hat or CentOS version (for example, ``8``), then
-            - MongoDB :manual:`release version </reference/versioning>`
-              (for example, ``{+mdb-version+}``), then
-            - Architecture (for example, ``x86_64``).
+            1. Red Hat or CentOS version (for example, ``8``)
+            #. MongoDB :manual:`release version </reference/versioning>`
+               (for example, ``{+mdb-version+}``)
+            #. Architecture (for example, ``x86_64``)
 
         - id: aws2-tab
           name: Amazon Linux 2
@@ -54,12 +54,12 @@ content: |
             You can also download the ``.rpm`` files directly from the
             `MongoDB repository
             <https://repo.mongodb.org/yum/amazon/>`__. Downloads are
-            organized by:
+            organized in the following order:
             
-            - Amazon Linux version (for example, ``2``), then
-            - MongoDB :manual:`release version </reference/versioning>`
-              (for example, ``{+mdb-version+}``), then
-            - Architecture (for example, ``x86_64``).
+            1. Amazon Linux version (for example, ``2``), then
+            #. MongoDB :manual:`release version </reference/versioning>`
+               (for example, ``{+mdb-version+}``), then
+            #. Architecture (for example, ``x86_64``).
 
 ---
 title: Install ``mongosh``.

--- a/source/includes/steps-install-shell-linux-rpm.yaml
+++ b/source/includes/steps-install-shell-linux-rpm.yaml
@@ -50,7 +50,7 @@ content: |
 
                [mongodb-org-{+mdb-version+}]
                name=MongoDB Repository
-               baseurl=https://repo.mongodb.org/yum/amazon/2/mongodb-org/{+mdb-version+}/x86_64/
+               baseurl=https://repo.mongodb.org/yum/amazon/$releasever/mongodb-org/{+mdb-version+}/$basearch/
                gpgcheck=1
                enabled=1
                gpgkey=https://www.mongodb.org/static/pgp/server-{+pgp-version+}.asc 

--- a/source/includes/steps-install-shell-linux-rpm.yaml
+++ b/source/includes/steps-install-shell-linux-rpm.yaml
@@ -43,7 +43,7 @@ content: |
             #. Architecture (for example, ``x86_64``)
 
         - id: aws2-tab
-          name: Amazon Linux 2
+          name: Amazon Linux
           content: |
 
             .. code-block:: shell


### PR DESCRIPTION
## DESCRIPTION

This PR updates the MDB version used in Amazon Linux instructions from 5.0 > 6.0. Note that I have not tested this myself, and am just using the same versioning used on the RHEL tab.

## JIRA

https://jira.mongodb.org/browse/DOCSP-27120

## STAGED

https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-27120/install/ (Linux tab > .rpm tab)