### PR TITLE
remove unnecessary (and deprecated) class directives

### DIFF
--- a/source/crud.txt
+++ b/source/crud.txt
@@ -59,12 +59,10 @@ remove. These filters use the same syntax as read operations.
 
 For examples, see :ref:`mongosh-delete`.
 
-.. class:: hidden
+.. toctree::
+   :titlesonly:
 
-   .. toctree::
-      :titlesonly:
-
-      /crud/insert
-      /crud/read
-      /crud/update
-      /crud/delete
+   /crud/insert
+   /crud/read
+   /crud/update
+   /crud/delete

--- a/source/reference.txt
+++ b/source/reference.txt
@@ -4,15 +4,13 @@ Reference
 
 .. default-domain:: mongodb
 
-.. class:: hidden
+.. toctree::
+   :titlesonly:
 
-   .. toctree::
-      :titlesonly:
-
-      /reference/compatibility
-      /reference/data-types
-      /reference/methods
-      /mongoshrc
-      /reference/options
-      /changelog
-      /logs
+   /reference/compatibility
+   /reference/data-types
+   /reference/methods
+   /mongoshrc
+   /reference/options
+   /changelog
+   /logs

--- a/source/snippets.txt
+++ b/source/snippets.txt
@@ -72,8 +72,6 @@ management, and configure a registry to share them.
   <https://github.com/mongodb-labs/mongosh-snippets/tree/main/snippets>`__
   or :ref:`configure <snip-registry-config>` a private registry.
 
-.. class:: hidden
-
 .. toctree::
    :titlesonly:
 


### PR DESCRIPTION
Toctrees no longer produce visible output so the `.. class:: hidden` directive isn't doing anything anyways. We're removing support for it in a forthcoming Snooty release, so might as well clean it up and avoid a warning in your logs in advance. Cheers!