### PR TITLE
DOCSP-27869 dochub conflict update

### DIFF
--- a/source/connect.txt
+++ b/source/connect.txt
@@ -271,7 +271,7 @@ following actions:
 Non-genuine Deployments
 -----------------------
 
-The shell displays a warning message when connected to non-genuine
+The shell displays a warning message when you connect to non-genuine
 MongoDB instances. Non-genuine instances may behave differently from the
 official MongoDB instances due to missing, inconsistent, or incomplete
 features.

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -271,10 +271,10 @@ following actions:
 Non-genuine Deployments
 -----------------------
 
-Starting in ``mongosh`` 1.7.0, the shell displays a warning message when
-connected to non-genuine MongoDB instances. Non-genuine instances may
-behave differently from the official MongoDB instances due to missing,
-inconsistent, or incomplete features.
+The shell displays a warning message when connected to non-genuine
+MongoDB instances. Non-genuine instances may behave differently from the
+official MongoDB instances due to missing, inconsistent, or incomplete
+features.
 
 Limitations
 -----------

--- a/source/reference/compatibility.txt
+++ b/source/reference/compatibility.txt
@@ -132,8 +132,8 @@ legacy :binary:`mongo` shell. To disable retryable writes, use
 ObjectId Methods and Attributes
 -------------------------------
 
-These :ref:`ObjectId() <server-objectid>` methods work differently in
-``mongosh`` than in the legacy ``mongo`` shell.
+These :ref:`ObjectId() <core-object-id-class>` methods work differently
+in ``mongosh`` than in the legacy ``mongo`` shell.
 
 .. list-table::
    :header-rows: 1


### PR DESCRIPTION
## DESCRIPTION
The coded link in the old and new shell both point to the same dochub reference. This update makes the landing code generic so that reference will work for both shells. 

[STAGING](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-27869-dochub-conflict-update/connect/#non-genuine-deployments)

[JIRA](https://jira.mongodb.org/browse/DOCSP-27869)

[BUILD](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6425e78866f244bf57cea902)


## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)