### PR TITLE
DOCSP-28986 corrects config.set() example

### DIFF
--- a/source/reference/configure-shell-settings-api.txt
+++ b/source/reference/configure-shell-settings-api.txt
@@ -110,7 +110,7 @@ Settings specified with the ``config`` API:
 
    .. code-block:: javascript
 
-      config.set( "inspectDepth": 10 )
+      config.set( "inspectDepth", 10 )
 
    The value of ``inspectDepth`` becomes ``10``, and will remain ``10``
    even when ``mongosh`` is restarted.


### PR DESCRIPTION
## DESCRIPTION

Corrects `config.set()` example.

## STAGING

https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-28986/reference/configure-shell-settings-api/#behavior-with-configuration-file

## JIRA

https://jira.mongodb.org/browse/DOCSP-28986

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64302024b49106a49823f6db
## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)