### PR TITLE
(DOCSP-29075): Install page updates to clarify amazon 2023 support

### DIFF
--- a/source/install.txt
+++ b/source/install.txt
@@ -131,9 +131,9 @@ Select the appropriate tab for your operating system:
             - :abbr:`RHEL (Red Hat Enterprise Linux)`
             - Amazon Linux 2
 
-            .. important:: Amazon Linux 2023 Support
+            .. important:: Amazon Linux 2023 Availability
 
-               ``mongosh`` is **not** supported on Amazon Linux 2023.
+               ``mongosh`` is **not** available on Amazon Linux 2023.
 
             Procedure
             ~~~~~~~~~

--- a/source/install.txt
+++ b/source/install.txt
@@ -100,10 +100,6 @@ Select the appropriate tab for your operating system:
 
       - To install the ``.tgz`` tarball, click the ``.tgz`` tab.
 
-      
-
-      
-
       .. tabs::
       
          .. tab:: .deb

--- a/source/install.txt
+++ b/source/install.txt
@@ -133,7 +133,8 @@ Select the appropriate tab for your operating system:
 
             .. important:: Amazon Linux 2023 Availability
 
-               ``mongosh`` is **not** available on Amazon Linux 2023.
+               ``mongosh`` is **not** currently available on Amazon
+               Linux 2023.
 
             Procedure
             ~~~~~~~~~

--- a/source/install.txt
+++ b/source/install.txt
@@ -111,6 +111,7 @@ Select the appropriate tab for your operating system:
             :binary:`mongosh` is available as a :abbr:`PPA (Personal
             Package Archive)` for the following platforms:
             
+            - Ubuntu 22.04 (Jammy)
             - Ubuntu 20.04 (Focal)
             - Ubuntu 18.04 (Bionic)
 

--- a/source/install.txt
+++ b/source/install.txt
@@ -88,9 +88,6 @@ Select the appropriate tab for your operating system:
    .. tab::
       :tabid: linux
 
-      Procedure
-      ~~~~~~~~~
-
       Select the appropriate tab based on your Linux distribution and
       desired package from the tabs below:
 
@@ -103,27 +100,55 @@ Select the appropriate tab for your operating system:
 
       - To install the ``.tgz`` tarball, click the ``.tgz`` tab.
 
+      
+
+      
+
       .. tabs::
       
          .. tab:: .deb
             :tabid: deb
 
+            Supported Platforms
+            ~~~~~~~~~~~~~~~~~~~
+
             :binary:`mongosh` is available as a :abbr:`PPA (Personal
-            Package Archive)` for Ubuntu 20.04 (Focal) and Ubuntu 18.04
-            (Bionic).
+            Package Archive)` for the following platforms:
+            
+            - Ubuntu 20.04 (Focal)
+            - Ubuntu 18.04 (Bionic)
+
+            Procedure
+            ~~~~~~~~~
 
             .. include:: /includes/steps/install-shell-linux-deb.rst
 
          .. tab:: .rpm
             :tabid: rpm
+
+            Supported Platforms
+            ~~~~~~~~~~~~~~~~~~~
             
-            :binary:`mongosh` is available as ``yum`` package for
-            :abbr:`RHEL (Red Hat Enterprise Linux)` and Amazon Linux 2.
+            :binary:`mongosh` is available as ``yum`` package for the
+            following platforms:
+
+            - :abbr:`RHEL (Red Hat Enterprise Linux)`
+            - Amazon Linux 2
+
+            .. important:: Amazon Linux 2023 Support
+
+               ``mongosh`` is **not** supported on Amazon Linux 2023.
+
+            Procedure
+            ~~~~~~~~~
 
             .. include:: /includes/steps/install-shell-linux-rpm.rst
 
          .. tab:: .tgz
             :tabid: tgz
+
+            Procedure
+            ~~~~~~~~~
       
             .. include:: /includes/steps/install-shell-linux-generic.rst
 


### PR DESCRIPTION
## DESCRIPTION

Request was made in #docs to explicitly mention that we don't support amazon Linux 2023. We will support amazon Linux 2023 in the next mongosh release, 1.8.1, after which we will need to update this section again.

## STAGING

https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-29075/install/

## JIRA

https://jira.mongodb.org/browse/DOCSP-29075

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=643564b4b49106a4981a644c

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)