### PR TITLE
DOCSP-25783 Correct Log Paths

### DIFF
--- a/source/logs.txt
+++ b/source/logs.txt
@@ -49,10 +49,10 @@ history:
      - Path to History File
 
    * - macOS and Linux
-     - ``~/.mongodb/mongosh/.mongosh_repl_history``
+     - ``~/.mongodb/mongosh/mongosh_repl_history``
 
    * - Windows
-     - ``%UserProfile%/.mongodb/mongosh/.mongosh_repl_history``
+     - ``%UserProfile%/.mongodb/mongosh/mongosh_repl_history``
 
 Log Retention
 -------------


### PR DESCRIPTION
## DESCRIPTION

Removing `.` from log path for correctness.

## STAGING

https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-25783/logs/#view-mdb-shell-command-history

## JIRA

https://jira.mongodb.org/browse/DOCSP-25783

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6467c3c8df0f8173e91106f9

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)