### PR TITLE
DOCSP-28126 OIDC mongosh options and connection

### DIFF
--- a/source/connect.txt
+++ b/source/connect.txt
@@ -170,7 +170,7 @@ Option 2: Specify Members in Connection String
 ``````````````````````````````````````````````
 
 You can specify individual replica set members in the
-:manual:`connection string </reference/connection-string>`.
+:manual:`connection string </reference/connection-string>`. 
 
 For example, to connect to a three-member replica set named ``replA``,
 run the following command:

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -170,7 +170,7 @@ Option 2: Specify Members in Connection String
 ``````````````````````````````````````````````
 
 You can specify individual replica set members in the
-::`connection string </reference/connection-string>`.
+:manual:`connection string </reference/connection-string>`.
 
 For example, to connect to a three-member replica set named ``replA``,
 run the following command:

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -125,15 +125,16 @@ option for programmatic usage of ``mongosh``, like a :driver:`driver
 Connect with OpenID Connect
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To connect to a deployment using OpenID Connect, use the :option:`--authenticationMechanism` 
-option and set it to ``MONGODB-OIDC``. ``mongosh`` redirects you to a browser 
-where you enter your identity provider's log-in information. 
+To connect to a deployment using :manual:`OpenID Connect </core/security-oidc/>`, 
+use the :option:`--authenticationMechanism` option and set it to ``MONGODB-OIDC``. 
+``mongosh`` redirects you to a browser where you enter your identity provider's 
+log-in information. 
 
 For example, the following connects to a local deployment using ``MONGODB-OIDC``:
 
 .. code-block:: sh
 
-   mongosh "mongodb://localhost/" --authenticationMechanism MONGODB-OIDC
+   mongosh "mongodb://localhost/" --authenticationMechanism MONGODB-OIDC 
 
 Connect to a Replica Set
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -169,7 +170,7 @@ Option 2: Specify Members in Connection String
 ``````````````````````````````````````````````
 
 You can specify individual replica set members in the
-:manual:`connection string </reference/connection-string>`.
+::`connection string </reference/connection-string>`.
 
 For example, to connect to a three-member replica set named ``replA``,
 run the following command:

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -122,6 +122,19 @@ option for programmatic usage of ``mongosh``, like a :driver:`driver
    - To provision access to a MongoDB deployment, see :manual:`Database
      Users </core/security-users/>`.
 
+Connect with OpenID Connect
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To connect to a deployment using OpenID Connect, use the :option:`--authenticationMechanism` 
+option and set it to ``MONGODB-OIDC``. ``mongosh`` redirects you to a browser 
+where you enter your identity provider's log-in information. 
+
+For example, the following connects to a local deployment using ``MONGODB-OIDC``:
+
+.. code-block:: sh
+
+   mongosh "mongodb://localhost/" --authenticationMechanism MONGODB-OIDC
+
 Connect to a Replica Set
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/reference/options.txt
+++ b/source/reference/options.txt
@@ -518,7 +518,7 @@ Authentication Options
    Specifies the specific browser ``mongosh`` redirects you to when ``MONGODB-OIDC`` 
    is enabled.
 
-   This option is run with the system shell.  
+   This option is run with the system shell.
 
 .. option:: --password <password>, -p <password>
 

--- a/source/reference/options.txt
+++ b/source/reference/options.txt
@@ -518,7 +518,7 @@ Authentication Options
    Specifies the specific browser ``mongosh`` redirects you to when ``MONGODB-OIDC`` 
    is enabled.
 
-   This option is run with the system shell. 
+   This option is run with the system shell.  
 
 .. option:: --password <password>, -p <password>
 

--- a/source/reference/options.txt
+++ b/source/reference/options.txt
@@ -496,7 +496,7 @@ Authentication Options
 .. option:: --oidcRedirectUri
 
    Specifies a URI where the identity provider redirects you after authentication.
-   The default is ``http://localhost:27097/redirect``. 
+   The default is ``http://localhost:27097/redirect``.
 
 .. option:: --oidcTrustedEndpoint
 

--- a/source/reference/options.txt
+++ b/source/reference/options.txt
@@ -496,6 +496,7 @@ Authentication Options
 .. option:: --oidcRedirectUri
 
    Specifies a URI where the identity provider redirects you after authentication.
+   The URI must match the configuration of the Identity Provider used by the server.
    The default is ``http://localhost:27097/redirect``.
 
 .. option:: --oidcTrustedEndpoint
@@ -506,7 +507,7 @@ Authentication Options
 .. option:: --browser
 
    Specifies the specific browser ``mongosh`` redirects you to when ``MONGODB-OIDC`` 
-   is enabled. 
+   is enabled.
 
 .. option:: --password <password>, -p <password>
 

--- a/source/reference/options.txt
+++ b/source/reference/options.txt
@@ -441,6 +441,12 @@ Authentication Options
           `MongoDB Enterprise
           <http://www.mongodb.com/products/mongodb-enterprise-advanced?jmp=docs>`_.
 
+      * - :ref:`MONGODB-OIDC <authentication-oidc>` (OpenID Connect)
+
+        - External authentication using OpenID Connect. This mechanism is
+          available only in `MongoDB Enterprise
+          <http://www.mongodb.com/products/mongodb-enterprise-advanced?jmp=docs>`_.
+
 .. option:: --gssapiServiceName
 
    Specify the name of the service using
@@ -467,6 +473,40 @@ Authentication Options
      ``authMechanismProperties=CANONICALIZE_HOST_NAME:true``.
    - ``none``, the effect is the same as setting
      ``authMechanismProperties=CANONICALIZE_HOST_NAME:false``.
+
+.. option:: --oidcFlows
+
+   Specifies OpenID Connect flows. The OpenID connect flows specify how the ``mongosh``
+   interacts with identity provider for the authentication process. ``mongosh`` 
+   supports the following OpenID Connect flows:
+
+   .. list-table::
+      :header-rows: 1
+      :widths: 25 75
+
+      * - OpenID Connect Flow
+        - Description
+
+      * - ``auth-code``
+        - Default. ``mongosh`` redirects you to the identity provider log-in screen.
+
+      * - ``device-auth``
+        - ``mongosh`` provides you with a URL and code to finish authentication.    
+
+.. option:: --oidcRedirectUri
+
+   Specifies a URI where the identity provider redirects you after authentication.
+   The default is ``http://localhost:27097/redirect``. 
+
+.. option:: --oidcTrustedEndpoint
+
+   Specifies a connection to a trusted endpoint that is not Atlas or localhost. 
+   Only connect to hosts that you know are safe. 
+
+.. option:: --browser
+
+   Specifies the specific browser ``mongosh`` redirects you to when ``MONGODB-OIDC`` 
+   is enabled. 
 
 .. option:: --password <password>, -p <password>
 

--- a/source/reference/options.txt
+++ b/source/reference/options.txt
@@ -476,9 +476,10 @@ Authentication Options
 
 .. option:: --oidcFlows
 
-   Specifies OpenID Connect flows. The OpenID connect flows specify how the ``mongosh``
-   interacts with identity provider for the authentication process. ``mongosh`` 
-   supports the following OpenID Connect flows:
+   Specifies OpenID Connect flows in a comma-separated list. 
+   The OpenID connect flows specify how ``mongosh``interacts with the identity 
+   provider for the authentication process. ``mongosh`` supports the following 
+   OpenID Connect flows:
 
    .. list-table::
       :header-rows: 1
@@ -491,12 +492,20 @@ Authentication Options
         - Default. ``mongosh`` redirects you to the identity provider log-in screen.
 
       * - ``device-auth``
-        - ``mongosh`` provides you with a URL and code to finish authentication.    
+        - ``mongosh`` provides you with a URL and code to finish authentication.
+          This is considered a less secure OpenID Connect flow.
+
+   To set ``device-auth`` as a fallback option to ``auth-code``, see the following 
+   example:
+
+   .. code-block:: bash 
+
+      mongosh 'mongodb://localhost/' --authenticationMechanism MONGODB-OIDC --oidcFlows=auth-code,device-auth
 
 .. option:: --oidcRedirectUri
 
    Specifies a URI where the identity provider redirects you after authentication.
-   The URI must match the configuration of the Identity Provider used by the server.
+   The URI must match the configuration of the identity provider used by the server.
    The default is ``http://localhost:27097/redirect``.
 
 .. option:: --oidcTrustedEndpoint
@@ -508,6 +517,8 @@ Authentication Options
 
    Specifies the specific browser ``mongosh`` redirects you to when ``MONGODB-OIDC`` 
    is enabled.
+
+   This option is run with the system shell. 
 
 .. option:: --password <password>, -p <password>
 

--- a/source/reference/options.txt
+++ b/source/reference/options.txt
@@ -477,7 +477,7 @@ Authentication Options
 .. option:: --oidcFlows
 
    Specifies OpenID Connect flows in a comma-separated list. 
-   The OpenID connect flows specify how ``mongosh``interacts with the identity 
+   The OpenID Connect flows specify how ``mongosh`` interacts with the identity 
    provider for the authentication process. ``mongosh`` supports the following 
    OpenID Connect flows:
 
@@ -489,11 +489,13 @@ Authentication Options
         - Description
 
       * - ``auth-code``
-        - Default. ``mongosh`` redirects you to the identity provider log-in screen.
+        - Default. ``mongosh`` opens a browser and redirects you to the identity 
+          provider log-in screen.
 
       * - ``device-auth``
         - ``mongosh`` provides you with a URL and code to finish authentication.
-          This is considered a less secure OpenID Connect flow.
+          This is considered a less secure OpenID Connect flow but can be used when 
+          ``mongosh`` is run in an environment in which it cannot open a browser.
 
    To set ``device-auth`` as a fallback option to ``auth-code``, see the following 
    example:
@@ -505,17 +507,17 @@ Authentication Options
 .. option:: --oidcRedirectUri
 
    Specifies a URI where the identity provider redirects you after authentication.
-   The URI must match the configuration of the identity provider used by the server.
+   The URI must match the configuration of the identity provider.
    The default is ``http://localhost:27097/redirect``.
 
 .. option:: --oidcTrustedEndpoint
 
    Specifies a connection to a trusted endpoint that is not Atlas or localhost. 
-   Only connect to hosts that you know are safe. 
+   Only use this option when connecting to servers that you trust.
 
 .. option:: --browser
 
-   Specifies the specific browser ``mongosh`` redirects you to when ``MONGODB-OIDC`` 
+   Specifies the browser ``mongosh`` redirects you to when ``MONGODB-OIDC`` 
    is enabled.
 
    This option is run with the system shell. 

--- a/source/reference/options.txt
+++ b/source/reference/options.txt
@@ -518,7 +518,7 @@ Authentication Options
    Specifies the specific browser ``mongosh`` redirects you to when ``MONGODB-OIDC`` 
    is enabled.
 
-   This option is run with the system shell.
+   This option is run with the system shell. 
 
 .. option:: --password <password>, -p <password>
 


### PR DESCRIPTION
## DESCRIPTION
Documention new OIDC mongosh options and connection

## STAGING
https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-28126/connect/#connect-with-openid-connect 

https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-28126/reference/options/#authentication-options

## JIRA
https://jira.mongodb.org/browse/DOCSP-28126

## BUILD LOG

Build Error for `authentication-oidc` is because that page has not been merged into the feature branch yet. 
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6493079e259a8493e566f266

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)