### PR TITLE
(DOCSP-28700): Update mongosh install instructions for jammy

### DIFF
--- a/source/includes/steps-install-shell-linux-deb.yaml
+++ b/source/includes/steps-install-shell-linux-deb.yaml
@@ -44,12 +44,27 @@ content: |
    .. tabs::
 
       tabs:
+         - id: jammy
+           name: Ubuntu 22.04 (Jammy)
+           content: |
+
+              The following instruction is for **Ubuntu 22.04 (Jammy)**.
+              For other releases, click the appropriate tab.
+
+              Create the
+              ``/etc/apt/sources.list.d/mongodb-org-{+mdb-version+}.list``
+              file for Ubuntu 22.04 (Jammy):
+
+              .. code-block:: sh
+
+                 echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/{+mdb-version+} multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-{+mdb-version+}.list
+         
          - id: focal
            name: Ubuntu 20.04 (Focal)
            content: |
 
               The following instruction is for **Ubuntu 20.04 (Focal)**.
-              For Ubuntu 18.04 (Bionic) click on the appropriate tab.
+              For other releases, click the appropriate tab.
 
               Create the
               ``/etc/apt/sources.list.d/mongodb-org-{+mdb-version+}.list``

--- a/source/includes/steps-install-shell-linux-deb.yaml
+++ b/source/includes/steps-install-shell-linux-deb.yaml
@@ -10,9 +10,10 @@ content: |
 
        wget -qO- https://www.mongodb.org/static/pgp/server-{+pgp-version+}.asc | sudo tee /etc/apt/trusted.gpg.d/server-{+pgp-version+}.asc
 
-    The previous command prints the GPG key to the terminal and writes
-    the key to your system's ``/etc/apt/trusted.gpg.d/`` folder. You do
-    not need to copy or save the key that is printed to the terminal.
+    The previous command writes the GPG key to your system's
+    ``/etc/apt/trusted.gpg.d`` folder and prints the key to your
+    terminal. You do not need to copy or save the key that is printed to
+    the terminal.
     
     If you receive an error indicating that ``gnupg`` is not installed,
     perform the following steps:

--- a/source/includes/steps-install-shell-linux-deb.yaml
+++ b/source/includes/steps-install-shell-linux-deb.yaml
@@ -4,16 +4,16 @@ level: 4
 ref: import-key
 content: |
     From a terminal, issue the following command to import the
-    MongoDB public GPG Key from `<https://www.mongodb.org/static/pgp/server-{+pgp-version+}.asc>`_:
+    MongoDB public GPG key from `<https://www.mongodb.org/static/pgp/server-{+pgp-version+}.asc>`_:
 
     .. code-block:: sh
 
-       wget -qO - https://www.mongodb.org/static/pgp/server-{+pgp-version+}.asc | sudo apt-key add -
+       wget -qO- https://www.mongodb.org/static/pgp/server-{+pgp-version+}.asc | sudo tee /etc/apt/trusted.gpg.d/server-{+pgp-version+}.asc
 
-    The operation should respond with ``OK``. 
+    Your terminal prints the GPG key.
     
     If you receive an error indicating that ``gnupg`` is not installed,
-    you can:
+    perform the following steps:
        
     #. Install ``gnupg`` and its required libraries using the following command:
 
@@ -25,7 +25,7 @@ content: |
 
        .. code-block:: sh
 
-          wget -qO- https://www.mongodb.org/static/pgp/server-{+pgp-version+}.asc | sudo tee /etc/apt/keyrings
+          wget -qO- https://www.mongodb.org/static/pgp/server-{+pgp-version+}.asc | sudo tee /etc/apt/trusted.gpg.d/server-{+pgp-version+}.asc
 ---
 title: Create a list file for MongoDB.
 stepnum: 2

--- a/source/includes/steps-install-shell-linux-deb.yaml
+++ b/source/includes/steps-install-shell-linux-deb.yaml
@@ -10,10 +10,10 @@ content: |
 
        wget -qO - https://www.mongodb.org/static/pgp/server-{+pgp-version+}.asc | sudo apt-key add -
 
-    The operation should respond with an ``OK``. 
+    The operation should respond with ``OK``. 
     
-    However, if you receive an error indicating that ``gnupg`` is not
-    installed, you can:
+    If you receive an error indicating that ``gnupg`` is not installed,
+    you can:
        
     #. Install ``gnupg`` and its required libraries using the following command:
 
@@ -21,7 +21,7 @@ content: |
 
           sudo apt-get install gnupg
        
-    #. Once installed, retry importing the key:
+    #. Retry importing the key:
 
        .. code-block:: sh
 
@@ -39,7 +39,7 @@ content: |
 
    Click on the appropriate tab for your version of Ubuntu.
    If you are unsure of what Ubuntu version the host is running,
-   open a terminal or shell on the host and execute ``lsb_release -dc``. 
+   open a terminal or shell on the host and run ``lsb_release -dc``. 
 
    .. tabs::
 

--- a/source/includes/steps-install-shell-linux-deb.yaml
+++ b/source/includes/steps-install-shell-linux-deb.yaml
@@ -10,9 +10,9 @@ content: |
 
        wget -qO- https://www.mongodb.org/static/pgp/server-{+pgp-version+}.asc | sudo tee /etc/apt/trusted.gpg.d/server-{+pgp-version+}.asc
 
-    Your terminal prints the GPG key. You do not need to copy or save
-    the key that is printed to the terminal. The previous command writes
-    the key to your system's ``/etc/apt/trusted.gpg.d/`` folder.
+    The previous command prints the GPG key to the terminal and writes
+    the key to your system's ``/etc/apt/trusted.gpg.d/`` folder. You do
+    not need to copy or save the key that is printed to the terminal.
     
     If you receive an error indicating that ``gnupg`` is not installed,
     perform the following steps:

--- a/source/includes/steps-install-shell-linux-deb.yaml
+++ b/source/includes/steps-install-shell-linux-deb.yaml
@@ -128,4 +128,20 @@ content: |
   .. code-block:: sh 
 
      sudo apt-get install -y mongodb-mongosh-shared-openssl3
+---
+title: Confirm that ``mongosh`` installed successfully.
+stepnum: 5
+level: 4
+ref: confirm
+content: |
+
+  To confirm that ``mongosh`` installed successfully, run the following
+  command:
+
+  .. code-block:: sh
+
+     mongosh --version
+
+  Your terminal should respond with the version of ``mongosh`` you have
+  installed.
 ...

--- a/source/includes/steps-install-shell-linux-deb.yaml
+++ b/source/includes/steps-install-shell-linux-deb.yaml
@@ -49,7 +49,7 @@ content: |
            content: |
 
               The following instruction is for **Ubuntu 22.04 (Jammy)**.
-              For other releases, click the appropriate tab.
+              For other Ubuntu releases, click the appropriate tab.
 
               Create the
               ``/etc/apt/sources.list.d/mongodb-org-{+mdb-version+}.list``
@@ -64,7 +64,7 @@ content: |
            content: |
 
               The following instruction is for **Ubuntu 20.04 (Focal)**.
-              For other releases, click the appropriate tab.
+              For other Ubuntu releases, click the appropriate tab.
 
               Create the
               ``/etc/apt/sources.list.d/mongodb-org-{+mdb-version+}.list``
@@ -79,7 +79,7 @@ content: |
            content: |
 
               The following instruction is for **Ubuntu 18.04
-              (Bionic)**. For Ubuntu 20.04 (Focal) click on the
+              (Bionic)**. For other Ubuntu releases, click the
               appropriate tab.
 
               Create the

--- a/source/includes/steps-install-shell-linux-deb.yaml
+++ b/source/includes/steps-install-shell-linux-deb.yaml
@@ -25,7 +25,7 @@ content: |
 
        .. code-block:: sh
 
-          wget -qO - https://www.mongodb.org/static/pgp/server-{+pgp-version+}.asc | sudo apt-key add -
+          wget -qO- https://www.mongodb.org/static/pgp/server-{+pgp-version+}.asc | sudo tee /etc/apt/keyrings
 ---
 title: Create a list file for MongoDB.
 stepnum: 2

--- a/source/includes/steps-install-shell-linux-deb.yaml
+++ b/source/includes/steps-install-shell-linux-deb.yaml
@@ -10,7 +10,9 @@ content: |
 
        wget -qO- https://www.mongodb.org/static/pgp/server-{+pgp-version+}.asc | sudo tee /etc/apt/trusted.gpg.d/server-{+pgp-version+}.asc
 
-    Your terminal prints the GPG key.
+    Your terminal prints the GPG key. You do not need to copy or save
+    the key that is printed to the terminal. The previous command writes
+    the key to your system's ``/etc/apt/trusted.gpg.d/`` folder.
     
     If you receive an error indicating that ``gnupg`` is not installed,
     perform the following steps:

--- a/source/install.txt
+++ b/source/install.txt
@@ -91,8 +91,9 @@ Select the appropriate tab for your operating system:
       Select the appropriate tab based on your Linux distribution and
       desired package from the tabs below:
 
-      - To install the ``.deb`` package on Ubuntu 20.04 (Focal), Ubuntu
-        18.04 (Bionic), and Debian, click the ``.deb`` tab.
+      - To install the ``.deb`` package on Ubuntu 22.04 (Jammy), Ubuntu
+        20.04 (Focal), Ubuntu 18.04 (Bionic), or Debian, click the
+        ``.deb`` tab.
 
       - To install the ``.rpm`` package on
         :abbr:`RHEL (Red Hat Enterprise Linux)` or Amazon Linux 2,


### PR DESCRIPTION
## DESCRIPTION

Add jammy install instructions for mongosh

## STAGING

https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-28700/install/ (Linux tab > deb tab)

## JIRA

https://jira.mongodb.org/browse/DOCSP-28700

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6492fb55259a8493e5634d67

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)