### PR TITLE
DOCS-15627 Noted SCRAM-SHA-256 as default user auth mechanism

### DIFF
--- a/source/reference/options.txt
+++ b/source/reference/options.txt
@@ -391,9 +391,9 @@ Authentication Options
 
    .. note::
 
-      If you don't specify an ``authenticationMechanism``, MongoDB
-      attempts to use SCRAM-SHA-256. If this fails, it falls back to
-      SCRAM-SHA-1.
+      If you don't specify an ``authenticationMechanism``, the MongoDB
+      Shell attempts to use SCRAM-SHA-256. If this fails, it falls back
+      to SCRAM-SHA-1.
 
    .. list-table::
       :header-rows: 1

--- a/source/reference/options.txt
+++ b/source/reference/options.txt
@@ -389,7 +389,7 @@ Authentication Options
    Specifies the authentication mechanism the |mdb-shell| uses to
    authenticate to the :binary:`~bin.mongod` or :binary:`~bin.mongos`.
 
-   .. note:
+   .. note::
 
       If you don't specify an ``authenticationMechanism``, MongoDB
       attempts to use SCRAM-SHA-256. If this fails, it falls back to

--- a/source/reference/options.txt
+++ b/source/reference/options.txt
@@ -386,20 +386,10 @@ Authentication Options
 
 .. option:: --authenticationMechanism <name>
 
-   *Default*: SCRAM-SHA-1
+   Default: SCRAM-SHA-256
 
    Specifies the authentication mechanism the |mdb-shell| uses to
    authenticate to the :binary:`~bin.mongod` or :binary:`~bin.mongos`.
-
-   .. note::
-
-      Starting in version 4.0:
-
-      - MongoDB removes support for the deprecated MongoDB
-        Challenge-Response (``MONGODB-CR``) authentication mechanism.
-
-      -  MongoDB adds support for SCRAM mechanism using the SHA-256 hash
-         function (``SCRAM-SHA-256``).
 
    .. list-table::
       :header-rows: 1
@@ -415,7 +405,7 @@ Authentication Options
           Salted Challenge Response Authentication Mechanism using the
           SHA-1 hash function.
 
-      * - :ref:`SCRAM-SHA-256 <authentication-scram-sha-256>`
+      * - :ref:`SCRAM-SHA-256 <authentication-scram-sha-256>` (Default)
 
         - `RFC 7677 <https://tools.ietf.org/html/rfc7677>`_ standard
           Salted Challenge Response Authentication Mechanism using the

--- a/source/reference/options.txt
+++ b/source/reference/options.txt
@@ -386,10 +386,14 @@ Authentication Options
 
 .. option:: --authenticationMechanism <name>
 
-   Default: SCRAM-SHA-256
-
    Specifies the authentication mechanism the |mdb-shell| uses to
    authenticate to the :binary:`~bin.mongod` or :binary:`~bin.mongos`.
+
+   .. note:
+
+      If you don't specify an ``authenticationMechanism``, MongoDB
+      attempts to use SCRAM-SHA-256. If this fails, it falls back to
+      SCRAM-SHA-1.
 
    .. list-table::
       :header-rows: 1
@@ -405,19 +409,11 @@ Authentication Options
           Salted Challenge Response Authentication Mechanism using the
           SHA-1 hash function.
 
-          If you don't specify an ``authenticationMechanism``, MongoDB
-          attempts to use SCRAM-SHA-256. If this fails, it falls back to
-          SCRAM-SHA-1.
-
       * - :ref:`SCRAM-SHA-256 <authentication-scram-sha-256>`
 
         - `RFC 7677 <https://tools.ietf.org/html/rfc7677>`_ standard
           Salted Challenge Response Authentication Mechanism using the
           SHA-256 hash function.
-
-          If you don't specify an ``authenticationMechanism``, MongoDB
-          attempts to use SCRAM-SHA-256. If this fails, it falls back to
-          SCRAM-SHA-1.
 
           Requires featureCompatibilityVersion set to ``4.0``.
 

--- a/source/reference/options.txt
+++ b/source/reference/options.txt
@@ -405,11 +405,19 @@ Authentication Options
           Salted Challenge Response Authentication Mechanism using the
           SHA-1 hash function.
 
-      * - :ref:`SCRAM-SHA-256 <authentication-scram-sha-256>` (Default)
+          If you don't specify an ``authenticationMechanism``, MongoDB
+          attempts to use SCRAM-SHA-256. If this fails, it falls back to
+          SCRAM-SHA-1.
+
+      * - :ref:`SCRAM-SHA-256 <authentication-scram-sha-256>`
 
         - `RFC 7677 <https://tools.ietf.org/html/rfc7677>`_ standard
           Salted Challenge Response Authentication Mechanism using the
           SHA-256 hash function.
+
+          If you don't specify an ``authenticationMechanism``, MongoDB
+          attempts to use SCRAM-SHA-256. If this fails, it falls back to
+          SCRAM-SHA-1.
 
           Requires featureCompatibilityVersion set to ``4.0``.
 

--- a/source/reference/options.txt
+++ b/source/reference/options.txt
@@ -387,13 +387,10 @@ Authentication Options
 .. option:: --authenticationMechanism <name>
 
    Specifies the authentication mechanism the |mdb-shell| uses to
-   authenticate to the :binary:`~bin.mongod` or :binary:`~bin.mongos`.
-
-   .. note::
-
-      If you don't specify an ``authenticationMechanism``, the MongoDB
-      Shell attempts to use SCRAM-SHA-256. If this fails, it falls back
-      to SCRAM-SHA-1.
+   authenticate to the :binary:`~bin.mongod` or :binary:`~bin.mongos`. 
+   If you don't specify an ``authenticationMechanism``, the MongoDB
+   Shell attempts to use SCRAM-SHA-256. If this fails, it falls back to
+   SCRAM-SHA-1.
 
    .. list-table::
       :header-rows: 1

--- a/source/reference/options.txt
+++ b/source/reference/options.txt
@@ -388,9 +388,9 @@ Authentication Options
 
    Specifies the authentication mechanism the |mdb-shell| uses to
    authenticate to the :binary:`~bin.mongod` or :binary:`~bin.mongos`. 
-   If you don't specify an ``authenticationMechanism``, the MongoDB
-   Shell attempts to use SCRAM-SHA-256. If this fails, it falls back to
-   SCRAM-SHA-1.
+   If you don't specify an ``authenticationMechanism`` but provide user
+   credentials, the MongoDB Shell and drivers attempt to use
+   SCRAM-SHA-256. If this fails, they fall back to SCRAM-SHA-1.
 
    .. list-table::
       :header-rows: 1


### PR DESCRIPTION
## DESCRIPTION
Note that SCRAM-SHA-256 is the default user auth mechanism

## STAGING
[Options: authenticationMechanism](https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCS-15627-note-SCRAM-default-SHA-256/reference/options/#std-option-mongosh.--authenticationMechanism)

## JIRA
https://jira.mongodb.org/browse/DOCS-15627

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64b6d9a787b3b3604683ad7a

## SELF-REVIEW CHECKLIST (BACKPORT/QUICK WIN)

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?
- [x] Verify merge branch, and that there aren't conflicts

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)
