### PR TITLE
DOCSP-30813 Add buildInfo() Command and Binary Flag

### DIFF
--- a/source/includes/examples/ex-build-info-command.rst
+++ b/source/includes/examples/ex-build-info-command.rst
@@ -1,5 +1,5 @@
 Returns the following JSON-formatted document that describes 
-your ``mongosh`` build:
+your ``mongosh`` build and driver dependencies:
 
 .. code-block:: javascript
    :copyable: false

--- a/source/includes/examples/ex-build-info-command.rst
+++ b/source/includes/examples/ex-build-info-command.rst
@@ -1,0 +1,24 @@
+This command returns the following JSON document that describes your 
+``mongosh`` build:
+
+.. code-block:: javascript
+
+   {
+   version: '1.10.1',
+   distributionKind: 'packaged',
+   buildArch: 'x64',
+   buildPlatform: 'linux',
+   buildTarget: 'unknown',
+   buildTime: '2023-06-21T09:49:37.225Z',
+   gitVersion: '05ad91b4dd40382a13f27abe1ae8c3f9f52a38f7',
+   nodeVersion: 'v16.20.1',
+   opensslVersion: '3.1.1',
+   sharedOpenssl: true,
+   runtimeArch: 'x64',
+   runtimePlatform: 'darwin',
+   deps: {
+      nodeDriverVersion: '5.6.0',
+      libmongocryptVersion: undefined,
+      libmongocryptNodeBindingsVersion: undefined
+   }
+   }

--- a/source/includes/examples/ex-build-info-command.rst
+++ b/source/includes/examples/ex-build-info-command.rst
@@ -21,5 +21,5 @@ your ``mongosh`` build and driver dependencies:
       nodeDriverVersion: '5.6.0',
       libmongocryptVersion: undefined,
       libmongocryptNodeBindingsVersion: undefined
-   }
+    }
    }

--- a/source/includes/examples/ex-build-info-command.rst
+++ b/source/includes/examples/ex-build-info-command.rst
@@ -18,8 +18,6 @@ your ``mongosh`` build and driver dependencies:
    runtimeArch: 'x64',
    runtimePlatform: 'darwin',
    deps: {
-      nodeDriverVersion: '5.6.0',
-      libmongocryptVersion: undefined,
-      libmongocryptNodeBindingsVersion: undefined
+      nodeDriverVersion: '5.6.0'
    }
    }

--- a/source/includes/examples/ex-build-info-command.rst
+++ b/source/includes/examples/ex-build-info-command.rst
@@ -1,4 +1,5 @@
-Returns the following document that describes your ``mongosh`` build:
+Returns the following JSON-formatted document that describes 
+your ``mongosh`` build:
 
 .. code-block:: javascript
    :copyable: false

--- a/source/includes/examples/ex-build-info-command.rst
+++ b/source/includes/examples/ex-build-info-command.rst
@@ -18,6 +18,8 @@ your ``mongosh`` build and driver dependencies:
    runtimeArch: 'x64',
    runtimePlatform: 'darwin',
    deps: {
-      nodeDriverVersion: '5.6.0'
+      nodeDriverVersion: '5.6.0',
+      libmongocryptVersion: undefined,
+      libmongocryptNodeBindingsVersion: undefined
    }
    }

--- a/source/includes/examples/ex-build-info-command.rst
+++ b/source/includes/examples/ex-build-info-command.rst
@@ -5,21 +5,21 @@ your ``mongosh`` build and driver dependencies:
    :copyable: false
 
    {
-   version: '1.10.1',
-   distributionKind: 'packaged',
-   buildArch: 'x64',
-   buildPlatform: 'linux',
-   buildTarget: 'unknown',
-   buildTime: '2023-06-21T09:49:37.225Z',
-   gitVersion: '05ad91b4dd40382a13f27abe1ae8c3f9f52a38f7',
-   nodeVersion: 'v16.20.1',
-   opensslVersion: '3.1.1',
-   sharedOpenssl: true,
-   runtimeArch: 'x64',
-   runtimePlatform: 'darwin',
-   deps: {
-      nodeDriverVersion: '5.6.0',
-      libmongocryptVersion: undefined,
-      libmongocryptNodeBindingsVersion: undefined
-    }
+     version: '1.10.1',
+     distributionKind: 'packaged',
+     buildArch: 'x64',
+     buildPlatform: 'linux',
+     buildTarget: 'unknown',
+     buildTime: '2023-06-21T09:49:37.225Z',
+     gitVersion: '05ad91b4dd40382a13f27abe1ae8c3f9f52a38f7',
+     nodeVersion: 'v16.20.1',
+     opensslVersion: '3.1.1',
+     sharedOpenssl: true,
+     runtimeArch: 'x64',
+     runtimePlatform: 'darwin',
+     deps: {
+        nodeDriverVersion: '5.6.0',
+        libmongocryptVersion: undefined,
+        libmongocryptNodeBindingsVersion: undefined
+      }
    }

--- a/source/includes/examples/ex-build-info-command.rst
+++ b/source/includes/examples/ex-build-info-command.rst
@@ -2,6 +2,7 @@ This command returns the following JSON document that describes your
 ``mongosh`` build:
 
 .. code-block:: javascript
+   :copyable: false
 
    {
    version: '1.10.1',

--- a/source/includes/examples/ex-build-info-command.rst
+++ b/source/includes/examples/ex-build-info-command.rst
@@ -1,5 +1,4 @@
-This command returns the following JSON document that describes your 
-``mongosh`` build:
+Returns the following document that describes your ``mongosh`` build:
 
 .. code-block:: javascript
    :copyable: false

--- a/source/includes/examples/ex-build-info-flag.rst
+++ b/source/includes/examples/ex-build-info-flag.rst
@@ -1,5 +1,5 @@
 You can check the build information and driver dependencies of your 
-:binary:`~bin.mongosh` binary by running the following from command 
+:binary:`~bin.mongosh` binary by running the following command 
 from your terminal:
 
 .. code-block:: sh

--- a/source/includes/examples/ex-build-info-flag.rst
+++ b/source/includes/examples/ex-build-info-flag.rst
@@ -1,6 +1,6 @@
 You can check the build information and driver dependencies of your 
-:binary:`~bin.mongosh` binary by running the following from your 
-terminal:
+:binary:`~bin.mongosh` binary by running the following from command 
+from your terminal:
 
 .. code-block:: sh
 

--- a/source/includes/examples/ex-build-info-flag.rst
+++ b/source/includes/examples/ex-build-info-flag.rst
@@ -1,6 +1,5 @@
-You can check the build info of your ``mongosh`` binary with the 
-``--build-info`` flag. In your terminal or command shell, run 
-the following command:
+You can check the build info of your ``mongosh`` binary by 
+running the following from your terminal:
 
 .. code-block:: sh
 

--- a/source/includes/examples/ex-build-info-flag.rst
+++ b/source/includes/examples/ex-build-info-flag.rst
@@ -6,10 +6,11 @@ running the following from your terminal:
    mongosh --build-info
 
 The command returns the following JSON document that describes your 
-``mongosh`` build:
+``mongosh`` binary:
 
 .. code-block:: javascript
-
+   :copyable: false
+   
    {
    "version": "1.10.1",
    "distributionKind": "packaged",
@@ -25,37 +26,5 @@ The command returns the following JSON document that describes your
    "runtimePlatform": "darwin",
    "deps": {
       "nodeDriverVersion": "5.6.0"
-   }
-   }
-
-You can check the build info of your ``mongosh`` binary with the 
-``buildInfo()`` command. In ``mongosh`` run the following command:
-
-.. code-block:: javascript
-
-   buildInfo()
-
-The command returns the following JSON document that describes your 
-``mongosh`` build:
-
-.. code-block:: javascript
-
-   {
-   version: '1.10.1',
-   distributionKind: 'packaged',
-   buildArch: 'x64',
-   buildPlatform: 'linux',
-   buildTarget: 'unknown',
-   buildTime: '2023-06-21T09:49:37.225Z',
-   gitVersion: '05ad91b4dd40382a13f27abe1ae8c3f9f52a38f7',
-   nodeVersion: 'v16.20.1',
-   opensslVersion: '3.1.1',
-   sharedOpenssl: true,
-   runtimeArch: 'x64',
-   runtimePlatform: 'darwin',
-   deps: {
-      nodeDriverVersion: '5.6.0',
-      libmongocryptVersion: undefined,
-      libmongocryptNodeBindingsVersion: undefined
    }
    }

--- a/source/includes/examples/ex-build-info-flag.rst
+++ b/source/includes/examples/ex-build-info-flag.rst
@@ -12,19 +12,19 @@ This command returns the following JSON-formatted document:
    :copyable: false
 
    {
-   version: '1.10.1',
-   distributionKind: 'packaged',
-   buildArch: 'x64',
-   buildPlatform: 'linux',
-   buildTarget: 'unknown',
-   buildTime: '2023-06-21T09:49:37.225Z',
-   gitVersion: '05ad91b4dd40382a13f27abe1ae8c3f9f52a38f7',
-   nodeVersion: 'v16.20.1',
-   opensslVersion: '3.1.1',
-   sharedOpenssl: true,
-   runtimeArch: 'x64',
-   runtimePlatform: 'darwin',
-   deps: {
-      nodeDriverVersion: '5.6.0'
-    }
+     version: '1.10.1',
+     distributionKind: 'packaged',
+     buildArch: 'x64',
+     buildPlatform: 'linux',
+     buildTarget: 'unknown',
+     buildTime: '2023-06-21T09:49:37.225Z',
+     gitVersion: '05ad91b4dd40382a13f27abe1ae8c3f9f52a38f7',
+     nodeVersion: 'v16.20.1',
+     opensslVersion: '3.1.1',
+     sharedOpenssl: true,
+     runtimeArch: 'x64',
+     runtimePlatform: 'darwin',
+     deps: {
+        nodeDriverVersion: '5.6.0'
+      }
    }

--- a/source/includes/examples/ex-build-info-flag.rst
+++ b/source/includes/examples/ex-build-info-flag.rst
@@ -5,12 +5,11 @@ running the following from your terminal:
 
    mongosh --build-info
 
-The command returns the following JSON document that describes your 
-``mongosh`` binary:
+This command returns the following JSON-formatted document:
 
 .. code-block:: javascript
    :copyable: false
-   
+
    {
    "version": "1.10.1",
    "distributionKind": "packaged",

--- a/source/includes/examples/ex-build-info-flag.rst
+++ b/source/includes/examples/ex-build-info-flag.rst
@@ -12,19 +12,19 @@ This command returns the following JSON-formatted document:
    :copyable: false
 
    {
-   "version": "1.10.1",
-   "distributionKind": "packaged",
-   "buildArch": "x64",
-   "buildPlatform": "linux",
-   "buildTarget": "unknown",
-   "buildTime": "2023-06-21T09:49:37.225Z",
-   "gitVersion": "05ad91b4dd40382a13f27abe1ae8c3f9f52a38f7",
-   "nodeVersion": "v16.20.1",
-   "opensslVersion": "3.1.1",
-   "sharedOpenssl": true,
-   "runtimeArch": "x64",
-   "runtimePlatform": "darwin",
-   "deps": {
-      "nodeDriverVersion": "5.6.0"
-   }
+   version: '1.10.1',
+   distributionKind: 'packaged',
+   buildArch: 'x64',
+   buildPlatform: 'linux',
+   buildTarget: 'unknown',
+   buildTime: '2023-06-21T09:49:37.225Z',
+   gitVersion: '05ad91b4dd40382a13f27abe1ae8c3f9f52a38f7',
+   nodeVersion: 'v16.20.1',
+   opensslVersion: '3.1.1',
+   sharedOpenssl: true,
+   runtimeArch: 'x64',
+   runtimePlatform: 'darwin',
+   deps: {
+      nodeDriverVersion: '5.6.0'
+    }
    }

--- a/source/includes/examples/ex-build-info-flag.rst
+++ b/source/includes/examples/ex-build-info-flag.rst
@@ -1,5 +1,6 @@
-You can check the build info of your ``mongosh`` binary by 
-running the following from your terminal:
+You can check the build information and driver dependencies of your 
+:binary:`~bin.mongosh` binary by running the following from your 
+terminal:
 
 .. code-block:: sh
 

--- a/source/includes/fact-query-driver-versions.rst
+++ b/source/includes/fact-query-driver-versions.rst
@@ -1,0 +1,62 @@
+You can check the build info of your ``mongosh`` binary with the 
+``--build-info`` flag. In your terminal or command shell, run 
+the following command:
+
+.. code-block:: sh
+
+   mongosh --build-info
+
+The command returns the following JSON document that describes your 
+``mongosh`` build:
+
+.. code-block:: javascript
+
+   {
+   "version": "1.10.1",
+   "distributionKind": "packaged",
+   "buildArch": "x64",
+   "buildPlatform": "linux",
+   "buildTarget": "unknown",
+   "buildTime": "2023-06-21T09:49:37.225Z",
+   "gitVersion": "05ad91b4dd40382a13f27abe1ae8c3f9f52a38f7",
+   "nodeVersion": "v16.20.1",
+   "opensslVersion": "3.1.1",
+   "sharedOpenssl": true,
+   "runtimeArch": "x64",
+   "runtimePlatform": "darwin",
+   "deps": {
+      "nodeDriverVersion": "5.6.0"
+   }
+   }
+
+You can check the build info of your ``mongosh`` binary with the 
+``buildInfo()`` command. In ``mongosh`` run the following command:
+
+.. code-block:: javascript
+
+   buildInfo()
+
+The command returns the following JSON document that describes your 
+``mongosh`` build:
+
+.. code-block:: javascript
+
+   {
+   version: '1.10.1',
+   distributionKind: 'packaged',
+   buildArch: 'x64',
+   buildPlatform: 'linux',
+   buildTarget: 'unknown',
+   buildTime: '2023-06-21T09:49:37.225Z',
+   gitVersion: '05ad91b4dd40382a13f27abe1ae8c3f9f52a38f7',
+   nodeVersion: 'v16.20.1',
+   opensslVersion: '3.1.1',
+   sharedOpenssl: true,
+   runtimeArch: 'x64',
+   runtimePlatform: 'darwin',
+   deps: {
+      nodeDriverVersion: '5.6.0',
+      libmongocryptVersion: undefined,
+      libmongocryptNodeBindingsVersion: undefined
+   }
+   }

--- a/source/reference/methods.txt
+++ b/source/reference/methods.txt
@@ -392,6 +392,13 @@ Collection Methods
      - Opens a :manual:`change stream cursor </changeStreams>` on the
        collection.
 
+
+Build Info Methods
+------------------
+
+You can check the build info of your ``mongosh`` binary with the 
+``buildInfo()`` command.
+
 Connection Methods
 ------------------
 
@@ -847,6 +854,12 @@ Native Methods
    * - Method
 
      - Description
+
+   * - .. _mongosh-native-method-buildInfo():
+
+       ``buildInfo()``
+
+     - .. include:: /includes/examples/ex-build-info-command.rst
 
    * - .. _mongosh-native-method-cd:
 

--- a/source/reference/methods.txt
+++ b/source/reference/methods.txt
@@ -392,13 +392,6 @@ Collection Methods
      - Opens a :manual:`change stream cursor </changeStreams>` on the
        collection.
 
-
-Build Info Methods
-------------------
-
-You can check the build info of your ``mongosh`` binary with the 
-``buildInfo()`` command.
-
 Connection Methods
 ------------------
 

--- a/source/reference/options.txt
+++ b/source/reference/options.txt
@@ -20,8 +20,8 @@ General Options
 
 .. option:: --build-info
 
-   Returns a JSON-formatted document with build information and driver 
-   dependencies about your :binary:`~bin.mongosh` binary.
+   Returns a JSON-formatted document with information about
+   your :binary:`~bin.mongosh` build and driver dependencies.
 
    **Example: View Build Information**
 

--- a/source/reference/options.txt
+++ b/source/reference/options.txt
@@ -23,7 +23,7 @@ General Options
    Returns a JSON-formatted document with build information and driver 
    dependencies about your :binary:`~bin.mongosh` binary.
 
-   **Example: View Build Info**
+   **Example: View Build Information**
 
    .. include:: /includes/examples/ex-build-info-flag.rst
 

--- a/source/reference/options.txt
+++ b/source/reference/options.txt
@@ -10,8 +10,8 @@ Options
    :depth: 2
    :class: singlecol
 
-Use the following options to control various aspects of your
-|mdb-shell| connection and behavior.
+Use the following options to view and control various aspects of your
+|mdb-shell|.
 
 General Options
 ---------------

--- a/source/reference/options.txt
+++ b/source/reference/options.txt
@@ -23,6 +23,10 @@ General Options
    Returns a JSON-formatted document with information about the
    :binary:`~bin.mongosh` build.
 
+   **Example: View Build Info**
+
+   .. include:: /includes/examples/ex-build-info-flag.rst
+
 .. option:: --eval <javascript>
 
    Evaluates a JavaScript expression. You can use a single ``--eval``

--- a/source/reference/options.txt
+++ b/source/reference/options.txt
@@ -20,8 +20,8 @@ General Options
 
 .. option:: --build-info
 
-   Returns a JSON-formatted document with information about the
-   :binary:`~bin.mongosh` build.
+   Returns a JSON-formatted document with build information and driver 
+   dependencies about your :binary:`~bin.mongosh` binary.
 
    **Example: View Build Info**
 


### PR DESCRIPTION
## DESCRIPTION

Adding a code example for the `mongosh --build-info` flag and adding a native method to the `reference/methods` page for the `buildInfo()` command.

## STAGING

https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-30813/reference/methods/#native-methods

https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-30813/reference/options/#std-option-mongosh.--build-info


## JIRA

https://jira.mongodb.org/browse/DOCSP-30813

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64d398cc67dbe9101034dbf7

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)