### PR TITLE
DOCSP-27860 Add LDAP Auth Connection Details

### DIFF
--- a/source/connect.txt
+++ b/source/connect.txt
@@ -128,15 +128,24 @@ Connect with LDAP
 
 To connect to a deployment using :ref:`LDAP <security-ldap>`:
 
-- Set :option:`--authenticationMechanism <mongosh --authenticationMechanism>` 
-  to ``PLAIN``.
-
 - Set :option:`--username <mongosh --username>` to a username that 
   respects the :setting:`security.ldap.authz.queryTemplate`, or any 
   configured :setting:`security.ldap.userToDNMapping` template.
 
 - Set :option:`--password <mongosh --password>` to the appropriate 
   password.
+
+- Set :option:`--authenticationDatabase <mongosh --authenticationDatabase>` 
+  to ``$external``.
+
+.. important::
+
+   The ``$external`` argument must be placed in single quotes, not
+   double quotes, to prevent the shell from interpreting ``$external``
+   as a variable.
+
+- Set :option:`--authenticationMechanism <mongosh --authenticationMechanism>` 
+  to ``PLAIN``.
 
 .. warning::
 
@@ -160,11 +169,6 @@ If you do not specify the password to the :option:`--password <mongosh
 --password>` command-line option, :binary:`~bin.mongosh`
 prompts for the password.
 
-.. important::
-
-   The ``$external`` argument must be placed in single quotes, not
-   double quotes, to prevent the shell from interpreting ``$external``
-   as a variable.
 
 Connect to a Replica Set
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -126,17 +126,18 @@ option for programmatic usage of ``mongosh``, like a :driver:`driver
 Connect with LDAP
 ~~~~~~~~~~~~~~~~~
 
-When using :ref:`LDAP <security-ldap>` for authorization, users 
-connecting with ``mongosh`` must:
+When you are using ``mongosh`` with :ref:`LDAP <security-ldap>` for 
+authorization, you must: 
 
 - Set :option:`--authenticationMechanism <mongosh --authenticationMechanism>` 
   to ``PLAIN``.
 
-- Set :option:`--username <mongosh --username>` to a username that respects the
-  :setting:`security.ldap.authz.queryTemplate`, or any configured
-  :setting:`security.ldap.userToDNMapping` template.
+- Set :option:`--username <mongosh --username>` to a username that 
+  respects the :setting:`security.ldap.authz.queryTemplate`, or any 
+  configured :setting:`security.ldap.userToDNMapping` template.
 
-- Set :option:`--password <mongosh --password>` to the appropriate password.
+- Set :option:`--password <mongosh --password>` to the appropriate 
+  password.
 
 .. warning::
 

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -126,18 +126,11 @@ option for programmatic usage of ``mongosh``, like a :driver:`driver
 Connect with LDAP
 ~~~~~~~~~~~~~~~~~
 
-When using LDAP for authorization, users connecting via
-``mongosh`` must:
+When using :ref:`LDAP <security-ldap>` for authorization, users 
+connecting via ``mongosh`` must:
 
-- Set :option:`--authenticationMechanism <mongosh --authenticationMechanism>` to the appropriate authentication
-  mechanism.
-
-  If using :ref:`LDAP authentication <security-ldap>`, set this to ``PLAIN``.
-
-  If using :ref:`Kerberos authentication <security-kerberos>`, set this to
-  ``GSSAPI``.
-
-  If using :ref:`x.509 <security-auth-x509>`, set this to ``MONGODB-X.509``.
+- Set :option:`--authenticationMechanism <mongosh --authenticationMechanism>` 
+  to ``PLAIN``.
 
 - Set :option:`--username <mongosh --username>` to a username that respects the
   :setting:`security.ldap.authz.queryTemplate`, or any configured

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -127,7 +127,7 @@ Connect with LDAP
 ~~~~~~~~~~~~~~~~~
 
 When using :ref:`LDAP <security-ldap>` for authorization, users 
-connecting via ``mongosh`` must:
+connecting with ``mongosh`` must:
 
 - Set :option:`--authenticationMechanism <mongosh --authenticationMechanism>` 
   to ``PLAIN``.

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -129,8 +129,6 @@ Connect with LDAP
 When using LDAP for authorization, users connecting via
 ``mongosh`` must:
 
-- Set :option:`--authenticationDatabase <mongosh --authenticationDatabase>` to ``$external``.
-
 - Set :option:`--authenticationMechanism <mongosh --authenticationMechanism>` to the appropriate authentication
   mechanism.
 
@@ -146,6 +144,15 @@ When using LDAP for authorization, users connecting via
   :setting:`security.ldap.userToDNMapping` template.
 
 - Set :option:`--password <mongosh --password>` to the appropriate password.
+
+.. warning::
+
+   When you use one-time passwords with LDAP authentication, 
+   adding the 
+   :ref:`connection string options <connections-connection-options>` 
+   ``maxPoolSize=1&srvMaxHosts=1`` to your connection string is 
+   recommended to reduce the potential for 
+   connection failures.
 
 Include the :option:`--host <mongosh --host>` and 
 :option:`--port <mongosh --port>` of the MongoDB server, along with any 

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -126,8 +126,7 @@ option for programmatic usage of ``mongosh``, like a :driver:`driver
 Connect with LDAP
 ~~~~~~~~~~~~~~~~~
 
-When you are using ``mongosh`` with :ref:`LDAP <security-ldap>` for 
-authorization, you must: 
+To connect to a deployment using :ref:`LDAP <security-ldap>`:
 
 - Set :option:`--authenticationMechanism <mongosh --authenticationMechanism>` 
   to ``PLAIN``.

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -137,12 +137,9 @@ To connect to a deployment using :ref:`LDAP <security-ldap>`:
 
 - Set :option:`--authenticationDatabase <mongosh --authenticationDatabase>` 
   to ``$external``.
-
-.. important::
-
-   The ``$external`` argument must be placed in single quotes, not
-   double quotes, to prevent the shell from interpreting ``$external``
-   as a variable.
+  The ``$external`` argument must be placed in single quotes, not
+  double quotes, to prevent the shell from interpreting ``$external``
+  as a variable.
 
 - Set :option:`--authenticationMechanism <mongosh --authenticationMechanism>` 
   to ``PLAIN``.

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -150,8 +150,7 @@ When using LDAP for authorization, users connecting via
    When you use one-time passwords with LDAP authentication, adding 
    the :ref:`connection string options <connections-connection-options>` 
    ``maxPoolSize=1&srvMaxHosts=1`` to your connection string is 
-   recommended to reduce the potential for 
-   connection failures.
+   recommended to reduce the potential for connection failures.
 
 Include the :option:`--host <mongosh --host>` and 
 :option:`--port <mongosh --port>` of the MongoDB server, along with any 

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -147,9 +147,8 @@ When using LDAP for authorization, users connecting via
 
 .. warning::
 
-   When you use one-time passwords with LDAP authentication, 
-   adding the 
-   :ref:`connection string options <connections-connection-options>` 
+   When you use one-time passwords with LDAP authentication, adding 
+   the :ref:`connection string options <connections-connection-options>` 
    ``maxPoolSize=1&srvMaxHosts=1`` to your connection string is 
    recommended to reduce the potential for 
    connection failures.

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -122,6 +122,52 @@ option for programmatic usage of ``mongosh``, like a :driver:`driver
    - To provision access to a MongoDB deployment, see :manual:`Database
      Users </core/security-users/>`.
 
+
+Connect with LDAP
+~~~~~~~~~~~~~~~~~
+
+When using LDAP for authorization, users connecting via
+``mongosh`` must:
+
+- Set :option:`--authenticationDatabase <mongosh --authenticationDatabase>` to ``$external``.
+
+- Set :option:`--authenticationMechanism <mongosh --authenticationMechanism>` to the appropriate authentication
+  mechanism.
+
+  If using :ref:`LDAP authentication <security-ldap>`, set this to ``PLAIN``.
+
+  If using :ref:`Kerberos authentication <security-kerberos>`, set this to
+  ``GSSAPI``.
+
+  If using :ref:`x.509 <security-auth-x509>`, set this to ``MONGODB-X.509``.
+
+- Set :option:`--username <mongosh --username>` to a username that respects the
+  :setting:`security.ldap.authz.queryTemplate`, or any configured
+  :setting:`security.ldap.userToDNMapping` template.
+
+- Set :option:`--password <mongosh --password>` to the appropriate password.
+
+Include the :option:`--host <mongosh --host>` and 
+:option:`--port <mongosh --port>` of the MongoDB server, along with any 
+other options relevant to your deployment.
+
+For example, the following operation authenticates to a MongoDB server 
+running with LDAP authentication and authorization:
+
+.. code-block:: bash
+
+   mongosh --username alice@dba.example.com --password  --authenticationDatabase '$external' --authenticationMechanism "PLAIN"  --host "mongodb.example.com" --port 27017
+
+If you do not specify the password to the :option:`--password <mongosh
+--password>` command-line option, :binary:`~bin.mongosh`
+prompts for the password.
+
+.. important::
+
+   The ``$external`` argument must be placed in single quotes, not
+   double quotes, to prevent the shell from interpreting ``$external``
+   as a variable.
+
 Connect to a Replica Set
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -154,11 +154,11 @@ To connect to a deployment using :ref:`LDAP <security-ldap>`:
    recommended to reduce the potential for connection failures.
 
 Include the :option:`--host <mongosh --host>` and 
-:option:`--port <mongosh --port>` of the MongoDB server, along with any 
-other options relevant to your deployment.
+:option:`--port <mongosh --port>` of the MongoDB deployment, along with 
+any other options relevant to your deployment.
 
-For example, the following operation authenticates to a MongoDB server 
-running with LDAP authentication and authorization:
+For example, the following operation authenticates to a MongoDB 
+deployment running with LDAP authentication and authorization:
 
 .. code-block:: bash
 

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -133,7 +133,9 @@ To connect to a deployment using :ref:`LDAP <security-ldap>`:
   configured :setting:`security.ldap.userToDNMapping` template.
 
 - Set :option:`--password <mongosh --password>` to the appropriate 
-  password.
+  password. If you do not specify the password to the 
+  ``--password`` command-line option, ``mongosh`` prompts you for 
+  the password.
 
 - Set :option:`--authenticationDatabase <mongosh --authenticationDatabase>` 
   to ``$external``.
@@ -161,11 +163,6 @@ running with LDAP authentication and authorization:
 .. code-block:: bash
 
    mongosh --username alice@dba.example.com --password  --authenticationDatabase '$external' --authenticationMechanism "PLAIN"  --host "mongodb.example.com" --port 27017
-
-If you do not specify the password to the :option:`--password <mongosh
---password>` command-line option, :binary:`~bin.mongosh`
-prompts for the password.
-
 
 Connect to a Replica Set
 ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## DESCRIPTION

Adding LDAP connection details which are present in the manual at: https://www.mongodb.com/docs/manual/core/security-ldap-external/#connecting-to-a-mongodb-server-using-ldap-authorization but not currently listed under the connection page for `mongosh`.

## STAGING

https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-27860/connect/#connect-with-ldap


## JIRA

https://jira.mongodb.org/browse/DOCSP-27860

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64d6610f67dbe91010e5d98c

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)