### PR TITLE
DOCSP-32212-parsing-logic

### DIFF
--- a/source/changelog.txt
+++ b/source/changelog.txt
@@ -26,8 +26,8 @@ v2.0.0
 
 - ``mongosh`` returns binary values as ``Binary.createFromBase64(
   <base64String> )`` values instead of ``Binary( Buffer.from(
-  <base64String> ) )`` values. For example: ``binaryValue:
-    Binary.createFromBase64("SGVsbG8gV29ybGQhCg==")``
+  <base64String> ) )`` values. For example:
+  ``binaryValue:Binary.createFromBase64( "SGVsbG8gV29ybGQhCg==" )``
 
   For additional details, see :method:`Binary.createFromBase64()`.
 

--- a/source/changelog.txt
+++ b/source/changelog.txt
@@ -30,7 +30,9 @@ v2.0.0
     Binary.createFromBase64("SGVsbG8gV29ybGQhCg==")``
 
   For additional details, see :method:`Binary.createFromBase64()`.
-  
+
+- .. include:: /includes/boolean-logic-connection-strings.rst
+
 - Removes support for :ref:`Free Monitoring <free-monitoring-mongodb>`
   helper functions:
   

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -348,3 +348,7 @@ Limitations
 
   - ``zstd``
   - ``snappy``
+
+- Starting in ``mongosh`` 2.0.0:
+
+  .. include:: /includes/boolean-logic-connection-strings.rst

--- a/source/includes/boolean-logic-connection-strings.rst
+++ b/source/includes/boolean-logic-connection-strings.rst
@@ -1,6 +1,6 @@
 For boolean values in connection strings, you:
 
-- must use ``true`` and ``false`` only.
+- must use ``true`` or ``false``.
 - cannot use ``1``, ``y``, ``yes``, or ``t`` instead of ``true``. 
-- cannot use ``-1``, ``0``, ``f``, ``n``, or ``no`` instead of
+- cannot use ``-1``, ``0``, ``n``, ``no``, or ``f`` instead of
   ``false``. 

--- a/source/includes/boolean-logic-connection-strings.rst
+++ b/source/includes/boolean-logic-connection-strings.rst
@@ -1,4 +1,4 @@
-For boolean values in :manual:`connection string
+For boolean values in :manual:`connection strings
 </reference/connection-string>`, you:
 
 - must use ``true`` or ``false``.

--- a/source/includes/boolean-logic-connection-strings.rst
+++ b/source/includes/boolean-logic-connection-strings.rst
@@ -1,5 +1,6 @@
-In connection strings, you cannot use these as synonyms for ``true``:
-``1``, ``y``, ``yes``, or ``t``.
+For boolean values in connection strings, you:
 
-You cannot use , and ``-1``, ``0``, ``f``, ``n``, and ``no`` as synonyms
-for ``false``. You must use ``true`` and ``false`` only.
+- must use ``true`` and ``false`` only.
+- cannot use ``1``, ``y``, ``yes``, or ``t`` instead of ``true``. 
+- cannot use ``-1``, ``0``, ``f``, ``n``, or ``no`` instead of
+  ``false``. 

--- a/source/includes/boolean-logic-connection-strings.rst
+++ b/source/includes/boolean-logic-connection-strings.rst
@@ -1,4 +1,5 @@
-For boolean values in connection strings, you:
+For boolean values in :manual:`connection string
+</reference/connection-string>`, you:
 
 - must use ``true`` or ``false``.
 - cannot use ``1``, ``y``, ``yes``, or ``t`` instead of ``true``. 

--- a/source/includes/boolean-logic-connection-strings.rst
+++ b/source/includes/boolean-logic-connection-strings.rst
@@ -1,0 +1,5 @@
+In connection strings, you cannot use these as synonyms for ``true``:
+``1``, ``y``, ``yes``, or ``t``.
+
+You cannot use , and ``-1``, ``0``, ``f``, ``n``, and ``no`` as synonyms
+for ``false``. You must use ``true`` and ``false`` only.


### PR DESCRIPTION
## DESCRIPTION

Boolean logic updates for connection strings. Also fixed an unrelated minor formatting issue in the binary constructor output.

## STAGING

https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-32212-parsing-logic/changelog/#v2.0.0

https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-32212-parsing-logic/connect/#limitations

## JIRA

https://jira.mongodb.org/browse/DOCSP-32212

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64e6a04f57e37806c5b493f9

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)