### PR TITLE
DOCSP-31861-deprecated-fields

### DIFF
--- a/source/changelog.txt
+++ b/source/changelog.txt
@@ -33,8 +33,8 @@ v2.0.0
 
 - .. include:: /includes/boolean-logic-connection-strings.rst
 
-- The following fields are deprecated and :method:`sh.status()` no
-  longer returns the fields:
+- :method:`sh.status()` no longer returns these fields that were removed
+  from the server:
 
   - ``minCompatibleVersion``
   - ``currentVersion``

--- a/source/changelog.txt
+++ b/source/changelog.txt
@@ -33,14 +33,17 @@ v2.0.0
 
 - .. include:: /includes/boolean-logic-connection-strings.rst
 
-- :method:`sh.status()` no longer returns these :data:`config.version`
-  fields that were removed from the server:
+- The following :data:`config.version` fields were removed and
+  :method:`sh.status()` no longer returns the fields:
 
   - ``minCompatibleVersion``
   - ``currentVersion``
   - ``excluding``
   - ``upgradeId``
   - ``upgradeState``
+
+  To obtain version information, see the :ref:`feature compatibility
+  version (fcv) <view-fcv>`.
 
 - Removes support for :ref:`Free Monitoring <free-monitoring-mongodb>`
   helper functions:

--- a/source/changelog.txt
+++ b/source/changelog.txt
@@ -33,6 +33,15 @@ v2.0.0
 
 - .. include:: /includes/boolean-logic-connection-strings.rst
 
+- The following fields are deprecated and :method:`sh.status()` no
+  longer returns the fields:
+
+  - ``minCompatibleVersion``
+  - ``currentVersion``
+  - ``excluding``
+  - ``upgradeId``
+  - ``upgradeState``
+
 - Removes support for :ref:`Free Monitoring <free-monitoring-mongodb>`
   helper functions:
   

--- a/source/changelog.txt
+++ b/source/changelog.txt
@@ -34,7 +34,7 @@ v2.0.0
 - .. include:: /includes/boolean-logic-connection-strings.rst
 
 - The following :data:`config.version` fields were removed and
-  :method:`sh.status()` no longer returns the fields:
+  :method:`sh.status()` doesn't return the fields:
 
   - ``minCompatibleVersion``
   - ``currentVersion``

--- a/source/changelog.txt
+++ b/source/changelog.txt
@@ -33,8 +33,8 @@ v2.0.0
 
 - .. include:: /includes/boolean-logic-connection-strings.rst
 
-- The following :data:`config.version` fields were removed and
-  :method:`sh.status()` doesn't return the fields:
+- The following :data:`config.version` fields were removed and aren't
+  returned in the :method:`sh.status()` output:
 
   - ``minCompatibleVersion``
   - ``currentVersion``

--- a/source/changelog.txt
+++ b/source/changelog.txt
@@ -33,8 +33,8 @@ v2.0.0
 
 - .. include:: /includes/boolean-logic-connection-strings.rst
 
-- :method:`sh.status()` no longer returns these fields that were removed
-  from the server:
+- :method:`sh.status()` no longer returns these :data:`config.version`
+  fields that were removed from the server:
 
   - ``minCompatibleVersion``
   - ``currentVersion``


### PR DESCRIPTION
## DESCRIPTION

Remove sharding version fields.

## STAGING

https://docs-mongodbcom-staging.corp.mongodb.com/mongodb-shell/docsworker-xlarge/DOCSP-31861-deprecated-fields/changelog/#v2.0.0

## JIRA

https://jira.mongodb.org/browse/DOCSP-31861

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64ed2d7a24fcc731b44bf07f

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)