### PR TITLE
(DOCSP-32304): Add Atlas-centric content to Write Scripts page

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -18,6 +18,7 @@ toc_landing_pages = ["/run-commands",
 version = "1.10.6"
 mdb-version = "7.0"
 pgp-version = "{+mdb-version+}"
+atlas = "MongoDB Atlas"
 
 [substitutions]
 

--- a/source/includes/fact-compatibility.rst
+++ b/source/includes/fact-compatibility.rst
@@ -1,0 +1,11 @@
+You can |mongosh-action| for deployments hosted 
+in the following environments:
+
+- `{+atlas+} 
+  <https://www.mongodb.com/docs/atlas?tck=docs_server>`__: The fully
+  managed service for MongoDB deployments in the cloud
+- :ref:`MongoDB Enterprise <install-mdb-enterprise>`: The
+  subscription-based, self-managed version of MongoDB
+- :ref:`MongoDB Community <install-mdb-community-edition>`: The
+  source-available, free-to-use, and self-managed version of MongoDB
+  

--- a/source/write-scripts.txt
+++ b/source/write-scripts.txt
@@ -20,6 +20,17 @@ management.
 This tutorial introduces using the |mdb-shell| with JavaScript to
 access MongoDB.
 
+Compatibility
+-------------
+
+.. |mongosh-action| replace:: write scripts for the |mdb-shell|
+
+.. include:: /includes/fact-compatibility.rst
+
+To learn more about using the |mdb-shell| for deployments
+hosted in MongoDB Atlas, see :atlas:`Connect via mongosh 
+</mongo-shell-connection/>`.
+
 .. _mdb-shell-execute-file:
 
 Execute a JavaScript File
@@ -347,6 +358,31 @@ The following example:
 .. code-block:: javascript
 
    conn = Mongo();
+   db = conn.getDB("myDatabase");
+
+Connect to an Atlas Deployment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To :ref:`connect to a deployment <mdb-shell-connect>` 
+hosted in {+atlas+}, run the ``mongosh`` command with your 
+Atlas connection string. For example:
+
+.. code-block:: sh
+
+   mongosh "mongodb+srv://YOUR_CLUSTER_NAME.YOUR_HASH.mongodb.net/" --apiVersion YOUR_API_VERSION --username YOUR_USERNAME
+
+Once you've established a connection to your deployment, you can
+instantiate database connections directly from the |mdb-shell|.
+The following example:
+
+- Instantiates a connection to the current deployment by using the 
+  :method:`db.getMongo()` method.
+- Sets the global ``db`` variable to ``myDatabase`` by using the
+  :method:`Mongo.getDB()` method.
+
+.. code-block:: javascript
+
+   conn = db.getMongo()
    db = conn.getDB("myDatabase");
 
 Connect to a MongoDB Instance that Enforces Access Control


### PR DESCRIPTION
## DESCRIPTION
Adds compatibility information and Atlas section under Open a Connection based on [Atlas Top 250 Guidance](https://docs.google.com/spreadsheets/d/1XrNidGxI1JKjt-toUxzS8WSwny4oeftg44IyMsEkEss/edit#gid=646834221).


## STAGING
https://preview-mongodbdavidhou17.gatsbyjs.io/mongodb-shell/DOCSP-32304/write-scripts/

## JIRA
https://jira.mongodb.org/browse/DOCSP-32304

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=650df04c492df295cff2770b

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)