### PR TITLE
DOCSP-33172 added meta description for top 250 pages in docs-mongodb-shell

### DIFF
--- a/source/configure-mongosh.txt
+++ b/source/configure-mongosh.txt
@@ -6,6 +6,9 @@ Configure ``mongosh``
 
 .. default-domain:: mongodb
 
+.. meta:: 
+   :description: Learn how to configure mongosh behaviors and user experience.
+
 .. contents:: On this page
    :local:
    :backlinks: none

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -11,7 +11,7 @@ Connect to a Deployment
    :values: tutorial
 
 .. meta:: 
-   :description: How to use the MongoDB Shell to connect to a MongoDB Atlas cloud-hosted deployment, a local deployment, or another remote host with MongoDB Shell.
+   :description: How to use the MongoDB Shell to connect to a MongoDB Atlas cloud-hosted deployment, a local deployment, or another remote host.
    :keywords: server
 
 .. contents:: On this page

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -11,6 +11,7 @@ Connect to a Deployment
    :values: tutorial
 
 .. meta:: 
+   :description: How to use the MongoDB Shell to connect to a MongoDB Atlas cloud-hosted deployment, a local deployment, or another remote host with MongoDB Shell.
    :keywords: server
 
 .. contents:: On this page

--- a/source/crud.txt
+++ b/source/crud.txt
@@ -11,6 +11,7 @@ Perform CRUD Operations
    :values: reference
 
 .. meta:: 
+   :description: CRUD operations create, read, update, and delete documents within a MongoDB collection.
    :keywords: server
 
 .. contents:: On this page

--- a/source/crud.txt
+++ b/source/crud.txt
@@ -11,7 +11,7 @@ Perform CRUD Operations
    :values: reference
 
 .. meta:: 
-   :description: CRUD operations create, read, update, and delete documents within a MongoDB collection.
+   :description: Use the MongoDB Shell to create, read, update, and delete documents in a MongoDB collection.
    :keywords: server
 
 .. contents:: On this page

--- a/source/crud/delete.txt
+++ b/source/crud/delete.txt
@@ -11,6 +11,7 @@ Delete Documents
    :values: reference
 
 .. meta:: 
+   :description: Delete one or many documents from a MongoDB collection.
    :keywords: server, atlas, sample dataset
 
 .. contents:: On this page

--- a/source/crud/insert.txt
+++ b/source/crud/insert.txt
@@ -11,6 +11,7 @@ Insert Documents
    :values: reference
 
 .. meta:: 
+   :description: Insert single or multiple documents into a MongoDB collection.
    :keywords: server, atlas, sample dataset
 
 .. contents:: On this page

--- a/source/crud/read.txt
+++ b/source/crud/read.txt
@@ -11,6 +11,7 @@ Query Documents
    :values: reference
 
 .. meta:: 
+   :description: Use the db.collection.find() method in the MongoDB Shell to query documents in a collection.
    :keywords: server, atlas, sample dataset
    
 .. contents:: On this page

--- a/source/crud/update.txt
+++ b/source/crud/update.txt
@@ -11,6 +11,7 @@ Update Documents
    :values: reference
 
 .. meta:: 
+   :description: MongoDB provides methods to update a single document, update multiple documents, and replace a document. 
    :keywords: server, atlas, sample dataset
 
 .. contents:: On this page

--- a/source/crud/update.txt
+++ b/source/crud/update.txt
@@ -11,7 +11,7 @@ Update Documents
    :values: reference
 
 .. meta:: 
-   :description: MongoDB provides methods to update a single document, update multiple documents, and replace a document. 
+   :description: Use the MongoDB Shell to update a single document, update multiple documents, or replace a document. 
    :keywords: server, atlas, sample dataset
 
 .. contents:: On this page

--- a/source/index.txt
+++ b/source/index.txt
@@ -6,6 +6,9 @@
    :name: genre
    :values: reference
 
+.. meta:: 
+   :description: Use the MongoDB Shell REPL environment to test queries and interact with the data in your MongoDB database.
+
 .. program:: mongosh
 
 .. binary:: mongosh

--- a/source/index.txt
+++ b/source/index.txt
@@ -7,7 +7,7 @@
    :values: reference
 
 .. meta:: 
-   :description: Use the MongoDB Shell REPL environment to test queries and interact with the data in your MongoDB database.
+   :description: Use the MongoDB Shell to test queries and interact with the data in your MongoDB database.
 
 .. program:: mongosh
 

--- a/source/install.txt
+++ b/source/install.txt
@@ -11,7 +11,7 @@ Install ``mongosh``
    :values: tutorial
 
 .. meta:: 
-   :description: Prerequisites, compatibility issues, and how to install mongosh, the MongoDB shell.
+   :description: Prerequisites, compatibility issues, and installation instructions for mongosh, the MongoDB Shell.
    :keywords: server, atlas
 
 .. contents:: On this page

--- a/source/install.txt
+++ b/source/install.txt
@@ -11,6 +11,7 @@ Install ``mongosh``
    :values: tutorial
 
 .. meta:: 
+   :description: Prerequisites, compatibility issues, and how to install mongosh, the MongoDB shell.
    :keywords: server, atlas
 
 .. contents:: On this page

--- a/source/run-commands.txt
+++ b/source/run-commands.txt
@@ -11,7 +11,7 @@ Run Commands
    :values: reference
 
 .. meta:: 
-   :description: Use run commands in mongosh to  format input or output, create or switch databases, terminate a query, and clear the console.
+   :description: Use run commands in the MongoDB Shell to create or switch databases, terminate a query, or clear the console.
    :keywords: server, atlas
 
 .. contents:: On this page

--- a/source/run-commands.txt
+++ b/source/run-commands.txt
@@ -11,6 +11,7 @@ Run Commands
    :values: reference
 
 .. meta:: 
+   :description: Use run commands in mongosh to  format input or output, create or switch databases, terminate a query, and clear the console.
    :keywords: server, atlas
 
 .. contents:: On this page

--- a/source/write-scripts.txt
+++ b/source/write-scripts.txt
@@ -15,6 +15,7 @@ Write Scripts
    :values: javascript/typescript
 
 .. meta:: 
+   :description: Write scripts for the MongoDB Shell that modify data in MongoDB or perform administrative operations.
    :keywords: server
 
 .. contents:: On this page


### PR DESCRIPTION
Hey @mdb-ashley!  I'm working on a ticket to add meta descriptions to the top 250 pages that don't have them.  Here are the ones for the mongosh repo.  In most cases, I copied and pasted a summarizing sentence from the page text, but please feel free to edit as you see fit.

Thanks!
Sarah

## STAGING
https://preview-mongodbsarahemlin.gatsbyjs.io/mongodb-shell/master/

## JIRA
https://jira.mongodb.org/browse/DOCSP-33172

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=655bdb505b686d6bd943dcf6