### PR TITLE
mongosh and mongo quoting differences

### DIFF
--- a/source/reference/compatibility.txt
+++ b/source/reference/compatibility.txt
@@ -210,8 +210,8 @@ quotes on values. To reproduce the output of the legacy
 ``mongo`` shell, which wraps both the keys and string values in double quotes, 
 use ``mongosh --eval`` with :ref:`EJSON.stringify() <mongosh-ejson-stringify>`.
 
-For example, the following command returns the items in the ``sales`` collection
-with double quotes and indentation:
+For example, the following command returns the items in the ``sales``
+collection on the ``test`` database with double quotes and indentation:
 
 .. code-block:: shell
 

--- a/source/reference/compatibility.txt
+++ b/source/reference/compatibility.txt
@@ -217,7 +217,7 @@ with double quotes and indentation:
 
    mongosh --eval "EJSON.stringify(db.sales.findOne().toArray(), null, 2)"
 
-The output looks like this:
+The output looks like the following:
 
 .. code-block:: javascript
 

--- a/source/reference/compatibility.txt
+++ b/source/reference/compatibility.txt
@@ -202,12 +202,38 @@ in ``mongosh`` better align with the types used by the MongoDB Drivers.
    For more information on managing types, refer to the
    :manual:`schema validation overview </core/schema-validation>`.
 
-``--eval`` Behavior
--------------------
+Object Quoting Behavior
+-----------------------
 
-``mongosh --eval`` does not quote object keys in its output.
+``mongosh`` does not quote object keys in its output, and places single 
+quotes on values. To reproduce the output of the legacy
+``mongo`` shell, which wraps both the keys and string values in double quotes, 
+use ``mongosh --eval`` with :ref:`EJSON.stringify() <mongosh-ejson-stringify>`.
 
-.. include:: /includes/examples/ex-eval-output.rst
+For example, the following command returns the items in the ``sales`` collection
+with double quotes and indentation:
+
+.. code-block:: shell
+
+   mongosh --eval "EJSON.stringify(db.sales.findOne().toArray(), null, 2)"
+
+The output looks like this:
+
+.. code-block:: javascript
+
+   {
+        "_id": {
+             "$oid": "64da90c1175f5091debcab26"
+        },
+        "custId": 345,
+        "purchaseDate": {
+             "$date": "2023-07-04T00:00:00Z"
+        },
+        "quantity": 4,
+        "cost": {
+             "$numberDecimal": "100.60"
+        }
+   }
 
 Limitations on Database Calls
 -----------------------------

--- a/source/reference/ejson/stringify.txt
+++ b/source/reference/ejson/stringify.txt
@@ -155,7 +155,8 @@ To control how documents are passed to EJSON, use one of the ``mongosh``
 Examples
 --------
 
-To try these examples, first create the ``sales`` collection:
+To try these examples, first create a ``sales`` collection in the ``test`` 
+database:
 
 .. code-block:: javascript
 


### PR DESCRIPTION
## DESCRIPTION
Difference between mongosh and mongo in quoting keys and values goes beyond just --eval. Updated section to reflect this and show an example. 

## STAGING
https://preview-mongodbmongocaleb.gatsbyjs.io/mongodb-shell/DOCSP-34327/reference/compatibility/#object-quoting-behavior

## JIRA
https://jira.mongodb.org/browse/DOCSP-34327

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=655e90bf13dc9d16ea3eac63