### PR TITLE
DOCSP-35222 Add Mentions of Amazon Linux 2023

### DIFF
--- a/source/install.txt
+++ b/source/install.txt
@@ -52,6 +52,8 @@ You can install MongoDB Shell 2.0.0 on these operating systems:
 
        | Amazon Linux 2023 (x64 and ARM64)
 
+       | Amazon Linux 2 (x64 and ARM64)
+
        | Debian 11+
 
        | SLES 15
@@ -144,8 +146,8 @@ Select the appropriate tab for your operating system:
         ``.deb`` tab.
 
       - To install the ``.rpm`` package on
-        :abbr:`RHEL (Red Hat Enterprise Linux)` or Amazon Linux 2,
-        click the ``.rpm`` tab.
+        :abbr:`RHEL (Red Hat Enterprise Linux)`, Amazon Linux 2023, or Amazon 
+        Linux 2, click the ``.rpm`` tab.
 
       - To install the ``.tgz`` tarball, click the ``.tgz`` tab.
 
@@ -179,12 +181,8 @@ Select the appropriate tab for your operating system:
             following platforms:
 
             - :abbr:`RHEL (Red Hat Enterprise Linux)`
+            - Amazon Linux 2023
             - Amazon Linux 2
-
-            .. important:: Amazon Linux 2023 Availability
-
-               ``mongosh`` is **not** currently available on Amazon
-               Linux 2023.
 
             Procedure
             ~~~~~~~~~


### PR DESCRIPTION
## DESCRIPTION
- Fix inconsistencies regarding Amazon Linux version mentions on mongosh docs
  - Make sure both Amazon Linux 2 and 2023 are mentioned. 

## STAGING
- [Supported OS table](https://preview-mongodbajhuhmdb.gatsbyjs.io/mongodb-shell/DOCSP-35222-amazon-compatibility-consistency/install/#supported-operating-systems)
- [Linux .rpm tab](https://preview-mongodbajhuhmdb.gatsbyjs.io/mongodb-shell/DOCSP-35222-amazon-compatibility-consistency/install/#supported-platforms-1)

## JIRA
https://jira.mongodb.org/browse/DOCSP-35222

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65987ae4dcc0144a517dec9e

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)