### PR TITLE
DOCSP-35144 Mongosh 2.1.3 RN

### DIFF
--- a/source/changelog.txt
+++ b/source/changelog.txt
@@ -12,6 +12,20 @@ Release Notes
    :depth: 1
    :class: singlecol
 
+v2.1.3
+------
+
+*Released January 29, 2024*
+
+- :issue:`MONGOSH-1631` - Adds support for the new ``type`` field when creating 
+  search indexes for ``runCommand``, ``createSearchIndex``, and 
+  ``createSearchIndexes``commands.
+
+- :issue:`MONGOSH-1664` - Removes tests for ``validate`` command background 
+  option.
+
+`Full release notes available on JIRA <https://jira.mongodb.org/secure/ReleaseNote.jspa?projectId=17381&version=37823>`__.
+
 v2.1.0
 ------
 
@@ -27,6 +41,8 @@ v2.1.0
 - :issue:`MONGOSH-1527` – You can now iterate mongosh cursors with idiomatic 
   syntax: ``for (const doc of db.coll.find()) { }``. Previously, ``mongosh`` only supported ``.forEach`` 
   syntax for iteration.
+
+`Full release notes available on JIRA <https://jira.mongodb.org/secure/ReleaseNote.jspa?projectId=17381&version=36935>`__.
 
 v2.0.2
 ------

--- a/source/changelog.txt
+++ b/source/changelog.txt
@@ -19,7 +19,7 @@ v2.1.3
 
 - :issue:`MONGOSH-1631` - Adds support for the new ``type`` field when creating 
   search indexes for ``runCommand``, ``createSearchIndex``, and 
-  ``createSearchIndexes``commands.
+  ``createSearchIndexes`` commands.
 
 - :issue:`MONGOSH-1664` - Removes tests for ``validate`` command background 
   option.

--- a/source/changelog.txt
+++ b/source/changelog.txt
@@ -21,7 +21,7 @@ v2.1.3
   search indexes for ``runCommand``, ``createSearchIndex``, and 
   ``createSearchIndexes`` commands.
 
-- :issue:`MONGOSH-1664` - Removes tests for ``validate`` command background 
+- :issue:`MONGOSH-1664` - Removes tests for the ``validate`` command background 
   option.
 
 `Full release notes available on JIRA <https://jira.mongodb.org/secure/ReleaseNote.jspa?projectId=17381&version=37823>`__.


### PR DESCRIPTION
## DESCRIPTION
- Release notes for mongosh 2.1.3
- also adds jira link for 2.1.0

## STAGING
https://preview-mongodbajhuhmdb.gatsbyjs.io/mongodb-shell/DOCSP-35144-mongosh.2.1.3-release/changelog/#v2.1.3

## JIRA
https://jira.mongodb.org/browse/DOCSP-35144

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65c3f5176b2f17c95aec833c

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)