### PR TITLE
DOCSP-31008 document cap for number of log files

### DIFF
--- a/source/logs.txt
+++ b/source/logs.txt
@@ -57,5 +57,5 @@ history:
 Log Retention
 -------------
 
-``mongosh`` retains up to 100 log files for 30 days. Log files older than
-30 days are automatically deleted.
+``mongosh`` retains up to 100 log files for 30 days. ``mongosh``
+automatically deletes log files older than 30 days.

--- a/source/logs.txt
+++ b/source/logs.txt
@@ -57,5 +57,5 @@ history:
 Log Retention
 -------------
 
-``mongosh`` retains log files for 30 days. Log files older than
+``mongosh`` retains up to 100 log files for 30 days. Log files older than
 30 days are automatically deleted.


### PR DESCRIPTION
## DESCRIPTION
document cap for number of log files

## STAGING
https://preview-mongodbkanchanamongodb.gatsbyjs.io/mongodb-shell/DOCSP-31008/logs/#log-retention

## JIRA
https://jira.mongodb.org/browse/DOCSP-31008

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=65cf8f647111165982502075

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)