### PR TITLE
DOCSP-38001-shell-release-notes-2.2.2

### DIFF
--- a/source/changelog.txt
+++ b/source/changelog.txt
@@ -21,7 +21,7 @@ Fixes a bug in 2.2.0 where connections that use OIDC workforce
 authentication caused an error:
 
 - :issue:`MONGOSH-1743` - use JS Proxy for forwarding "lazy-loaded"
-  webpack function exports
+  webpack function exports.
 
 `Full release notes available on JIRA 
 <https://jira.mongodb.org/secure/ReleaseNote.jspa?projectId=17381&version=38341>`__.

--- a/source/changelog.txt
+++ b/source/changelog.txt
@@ -17,8 +17,8 @@ v2.2.2
 
 *Released March 26, 2024*
 
-Fixes a bug in 2.2.0 where connections that use OIDC workforce
-authentication caused an error:
+Fixes a bug where connections that use OIDC workforce authentication
+caused an error:
 
 - :issue:`MONGOSH-1743` - use JS Proxy for forwarding "lazy-loaded"
   webpack function exports.

--- a/source/changelog.txt
+++ b/source/changelog.txt
@@ -36,6 +36,9 @@ script mode:
 
 - :issue:`MONGOSH-1738` - ``require`` not working in script mode.
 
+`Full release notes available on JIRA 
+<https://jira.mongodb.org/secure/ReleaseNote.jspa?projectId=17381&version=38287>`__.
+
 v2.2.0
 ------
 

--- a/source/changelog.txt
+++ b/source/changelog.txt
@@ -12,6 +12,20 @@ Release Notes
    :depth: 1
    :class: singlecol
 
+v2.2.2
+------
+
+*Released March 26, 2024*
+
+Fixes a bug in 2.2.0 where connections that use OIDC workforce
+authentication caused an error:
+
+- :issue:`MONGOSH-1743` - use JS Proxy for forwarding "lazy-loaded"
+  webpack function exports
+
+`Full release notes available on JIRA 
+<https://jira.mongodb.org/secure/ReleaseNote.jspa?projectId=17381&version=38080>`__.
+
 v2.2.1
 ------
 

--- a/source/changelog.txt
+++ b/source/changelog.txt
@@ -24,7 +24,7 @@ authentication caused an error:
   webpack function exports
 
 `Full release notes available on JIRA 
-<https://jira.mongodb.org/secure/ReleaseNote.jspa?projectId=17381&version=38080>`__.
+<https://jira.mongodb.org/secure/ReleaseNote.jspa?projectId=17381&version=38341>`__.
 
 v2.2.1
 ------


### PR DESCRIPTION
## DESCRIPTION

Shell 2.2.2 release notes.

## STAGING

https://preview-mongodbjasonpricemongodb.gatsbyjs.io/mongodb-shell/DOCSP-38001-shell-release-notes-2.2.2/changelog/#v2.2.2

## JIRA

https://jira.mongodb.org/browse/MONGOSH-1748

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=660300f86fc5f048501b3e87

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)