### PR TITLE
DOCSP-33875 Fixes mongosh typo

### DIFF
--- a/source/reference/options.txt
+++ b/source/reference/options.txt
@@ -174,7 +174,7 @@ Connection Options
 
          .. code-block:: none
 
-            mongodb+srv://server.example.com/?connectionTimeout=3000ms
+            mongodb+srv://server.example.com/?connectionTimeoutMS=3000ms
 
 .. option:: --port <port>
 

--- a/source/reference/options.txt
+++ b/source/reference/options.txt
@@ -174,7 +174,7 @@ Connection Options
 
          .. code-block:: none
 
-            mongodb+srv://server.example.com/?connectionTimeoutMS=3000ms
+            mongodb+srv://server.example.com/?connectionTimeoutMS=3000
 
 .. option:: --port <port>
 


### PR DESCRIPTION
## DESCRIPTION

Fixes typo in connection string on Options page.


## STAGING

Example block for [--host](https://preview-mongodbkennethdyer.gatsbyjs.io/mongodb-shell/DOCSP-33875-mongosh-typo/reference/options/#std-option-mongosh.--host)

## JIRA

[DOCSP-33875](https://jira.mongodb.org/browse/DOCSP-33875)

## BUILD LOG
* [2024-04-11](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=661851b93a5920a2915b3c66)
* [2024-04-12](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=66197a273a5920a2919fed47)

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)