### PR TITLE
DOCSP-38360 filling out snippets reference page

### DIFF
--- a/source/snippets/reference.txt
+++ b/source/snippets/reference.txt
@@ -17,8 +17,8 @@ Snippets Reference
    :ref:`snippets <snip-overview>`.
 
 :ref:`snip-configure`
-   Options control the interaction between  ``mongosh`` and the package
-   manager that tracks individual snippet packages.
+   Options to control the interaction between ``mongosh`` and the
+   package manager that tracks individual snippet packages.
 
 :ref:`snip-errors`
    Expressions to catch runtime errors and display custom error messages.

--- a/source/snippets/reference.txt
+++ b/source/snippets/reference.txt
@@ -12,6 +12,20 @@ Snippets Reference
    :depth: 1
    :class: singlecol
 
+:ref:`snip-commands`
+An overview of the commands that are available to work with
+:ref:`snippets <snip-overview>`.
+
+:ref:`snip-configure`
+Options control the interaction between  ``mongosh`` and the package
+manager that tracks individual snippet packages.
+
+:ref:`snip-errors`
+Expressions to catch runtime errors and display custom error messages.
+
+:ref:`snip-manual-reg-index`
+Steps to  manually create a registry index file.
+
 .. toctree::
    :titlesonly:
 

--- a/source/snippets/reference.txt
+++ b/source/snippets/reference.txt
@@ -13,18 +13,18 @@ Snippets Reference
    :class: singlecol
 
 :ref:`snip-commands`
-An overview of the commands that are available to work with
-:ref:`snippets <snip-overview>`.
+   An overview of the commands that are available to work with
+   :ref:`snippets <snip-overview>`.
 
 :ref:`snip-configure`
-Options control the interaction between  ``mongosh`` and the package
-manager that tracks individual snippet packages.
+   Options control the interaction between  ``mongosh`` and the package
+   manager that tracks individual snippet packages.
 
 :ref:`snip-errors`
-Expressions to catch runtime errors and display custom error messages.
+   Expressions to catch runtime errors and display custom error messages.
 
 :ref:`snip-manual-reg-index`
-Steps to  manually create a registry index file.
+   Steps to manually create a registry index file.
 
 .. toctree::
    :titlesonly:

--- a/source/snippets/reference.txt
+++ b/source/snippets/reference.txt
@@ -21,7 +21,8 @@ Snippets Reference
    package manager that tracks individual snippet packages.
 
 :ref:`snip-errors`
-   Expressions to catch runtime errors and display custom error messages.
+   Error handlers to specify regular expressions to catch runtime errors
+   and display custom error messages.
 
 :ref:`snip-manual-reg-index`
    Steps to manually create a registry index file.


### PR DESCRIPTION
## DESCRIPTION

Adding text to the snippets reference page 

## STAGING

https://preview-mongodbltranmdb2.gatsbyjs.io/mongodb-shell/DOCSP-38360/snippets/reference/

## JIRA

https://jira.mongodb.org/browse/DOCSP-38360

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=664e2c6ccf5bec1c29c0bcd2

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)