### PR TITLE
DOCSP-41453 macOS-install-instructions

### DIFF
--- a/source/includes/steps-install-shell-base.yaml
+++ b/source/includes/steps-install-shell-base.yaml
@@ -23,7 +23,7 @@ content: |
      .. code-block:: sh
 
        sudo cp mongosh /usr/local/bin/
-       sudo cp mongosh_crypt_v1.so /usr/local/lib/
+       sudo cp mongosh_crypt_v1.dylib /usr/local/lib/
 
    - Create symbolic links to the ``MongoDB Shell``. Switch to the
      directory where you extracted the files from the ``.tgz`` archive.

--- a/source/includes/steps-install-shell-macos.yaml
+++ b/source/includes/steps-install-shell-macos.yaml
@@ -12,6 +12,7 @@ content: |
    Download the appropriate version of ``mongosh`` for your operating
    system. MongoDB provides versions of ``mongosh`` for Intel and ARM 
    architectures. 
+
 ---
 title: "Extract the files from the downloaded archive."
 ref: extract-zip-macos

--- a/source/includes/steps-install-shell-macos.yaml
+++ b/source/includes/steps-install-shell-macos.yaml
@@ -11,8 +11,7 @@ level: 4
 content: |
    Download the appropriate version of ``mongosh`` for your operating
    system. MongoDB provides versions of ``mongosh`` for Intel and ARM 
-   architectures. 
-
+   architectures.
 ---
 title: "Extract the files from the downloaded archive."
 ref: extract-zip-macos

--- a/source/includes/steps-install-shell-macos.yaml
+++ b/source/includes/steps-install-shell-macos.yaml
@@ -12,10 +12,6 @@ content: |
    Download the appropriate version of ``mongosh`` for your operating
    system. MongoDB provides versions of ``mongosh`` for Intel and ARM 
    architectures. 
-   
-   See the `MongoDB Download Center
-   <https://www.mongodb.com/try/download/shell?jmp=docs>`__.
-
 ---
 title: "Extract the files from the downloaded archive."
 ref: extract-zip-macos


### PR DESCRIPTION
## DESCRIPTION

- Updating file extension in step 4 macOS install instructions, to `sudo cp mongosh_crypt_v1.dylib /usr/local/lib/`

I think existing info warnings in BL, are not relevant to this PR:

```
INFO(includes/steps-install-shell-linux-deb.yaml:0ish): Detect tabs that contain tabs that contain procedures: : "tabs tab tabs tab include procedure" 
INFO(includes/steps-install-shell-linux-rpm.yaml:0ish): Detect tabs that contain tabs that contain procedures: : "tabs tab tabs tab include procedure" 
INFO(includes/steps-install-shell-linux-generic.yaml:0ish): Detect tabs that contain tabs that contain procedures: : "tabs tab tabs tab include procedure" 
```

## STAGING

(MacOS Tab)
https://preview-mongodbianfmongodb.gatsbyjs.io/mongodb-shell/DOCSP-41453/install/


## JIRA

https://jira.mongodb.org/browse/DOCSP-41453

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=66957d35fb8bd13b8425c850

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)