### PR TITLE
DOCSP-41500 remove 404 link to deprecated command

### DIFF
--- a/source/reference/methods.txt
+++ b/source/reference/methods.txt
@@ -324,8 +324,8 @@ Collection Methods
 
    * - :method:`db.collection.getShardVersion()`
 
-     - Provides a wrapper for the database command :manual:`getShardVersion
-       </reference/command/getShardVersion/>`.
+     - Returns information regarding the state of data in a sharded 
+       cluster.
 
    * - :method:`db.collection.insertOne()`
 


### PR DESCRIPTION
## DESCRIPTION
`db.collection.getShardVersion()` description contained a link to the database command `getShardVersion` which has been deprecated. As a result, the link 404s.

This update removes the broken link and replaces the description with a brief description of the method's functionality.

## STAGING
https://preview-mongodbjwilsonmdb.gatsbyjs.io/mongodb-shell/DOCSP-41500/reference/methods/#:~:text=db.collection.getShardVersion()

## JIRA
https://jira.mongodb.org/browse/DOCSP-41500

## BUILD LOG
https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=6696a16526eba795526fd297

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)