### PR TITLE
DOCSP-42501 fixes command mistype in mongosh install doc

### DIFF
--- a/source/includes/steps-install-shell-base.yaml
+++ b/source/includes/steps-install-shell-base.yaml
@@ -23,7 +23,7 @@ content: |
      .. code-block:: sh
 
        sudo cp mongosh /usr/local/bin/
-       sudo cp mongosh_crypt_v1.dylib /usr/local/lib/
+       sudo cp mongosh_crypt_v1.so /usr/local/lib/
 
    - Create symbolic links to the ``MongoDB Shell``. Switch to the
      directory where you extracted the files from the ``.tgz`` archive.


### PR DESCRIPTION
## DESCRIPTION

Fixes command mistype in mongosh install doc.

## STAGING

https://preview-mongodbjmdmongo.gatsbyjs.io/mongodb-shell/DOCSP-42501/install/#add-the-downloaded-binaries-to-your-path-environment-variable-1

**Note to reviewer**: You may need to click through (Linux -> .tgz) to see the updated step 4 "Add the downloaded binaries to your PATH environment variable."

## JIRA

https://jira.mongodb.org/browse/DOCSP-42501

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=66bbaffe8383957117cbeedd

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)