### PR TITLE
DOCSP-42517-remove-duplicate-shell

### DIFF
--- a/source/reference/options.txt
+++ b/source/reference/options.txt
@@ -149,7 +149,7 @@ Connection Options
         <replSetName>/<hostname1><:port>,<hostname2><:port>,<...>
 
    For TLS/SSL connections (:option:`--tls <--tls>`),
-     The |mdb-shell| shell verifies that the hostname
+     The |mdb-shell| verifies that the hostname
      (specified in the :option:`--host <--host>` option or the
      connection string) matches the ``SAN`` (or, if ``SAN`` is not
      present, the ``CN``) in the certificate presented by the


### PR DESCRIPTION
## DESCRIPTION

- Removing duplicate `shell` typo from options page.

## STAGING

https://preview-mongodbianfmongodb.gatsbyjs.io/mongodb-shell/DOCSP-42517/reference/options/#connection-options

## JIRA

https://jira.mongodb.org/browse/DOCSP-42517

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=66be1eb68e811ae67225b5c9

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)