### PR TITLE
DOCSP-42955 mongosh v2.3.0 RN fix

### DIFF
--- a/source/changelog.txt
+++ b/source/changelog.txt
@@ -19,7 +19,7 @@ v2.3.0
 
 New features released in this version:
 
-- :issue:`MONGOSH-1550` - Adds support for Queryable Encryption Range queries and removes support for the Range Preview version
+- :issue:`MONGOSH-1550` - Adds support for Queryable Encryption Range queries and removes support for the Range Preview version. Removes support for out-of-the-box support for automatic encryption on deprecated Linux operating systems.
 - :issue:`MONGOSH-1827` - Adds configuration support for proxies in environment variables
 - :issue:`MONGOSH-1852` - ``--tlsUseSystemCA`` is enabled by default
 - :issue:`MONGOSH-1845` - Adds debug flag for dumping OIDC tokens to output

--- a/source/changelog.txt
+++ b/source/changelog.txt
@@ -19,7 +19,7 @@ v2.3.0
 
 New features released in this version:
 
-- :issue:`MONGOSH-1550` - Adds support for Queryable Encryption Range queries and removes support for the Range Preview version. Removes support for out-of-the-box support for automatic encryption on deprecated Linux operating systems.
+- :issue:`MONGOSH-1550` - Adds support for Queryable Encryption Range queries and removes support for the Range Preview version. Removes out-of-the-box support for automatic encryption on deprecated Linux operating systems.
 - :issue:`MONGOSH-1827` - Adds configuration support for proxies in environment variables
 - :issue:`MONGOSH-1852` - ``--tlsUseSystemCA`` is enabled by default
 - :issue:`MONGOSH-1845` - Adds debug flag for dumping OIDC tokens to output


### PR DESCRIPTION
## DESCRIPTION

DOCSP-42955 mongosh v2.3.0 RN fix

Adds "removes support for out-of-the-box support for automatic encryption on deprecated Linux operating systems" to [MONGOSH-1550](https://jira.mongodb.org/browse/MONGOSH-1550) desc in the release notes for mongosh 2.3.0.

## STAGING

https://preview-mongodbjmdmongo.gatsbyjs.io/mongodb-shell/DOCSP-42955/changelog/#v2.3.0

## JIRA

https://jira.mongodb.org/browse/DOCSP-42955

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=66cc9fc725dc1b90c7002877

## Self-Review Checklist

- [X] Is this free of any warnings or errors in the RST?
- [X] Is this free of spelling errors?
- [X] Is this free of grammatical errors?
- [X] Is this free of staging / rendering issues?
- [X] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)