### PR TITLE
DOCSP-42673-typo-options

### DIFF
--- a/source/reference/options.txt
+++ b/source/reference/options.txt
@@ -647,7 +647,7 @@ Client-Side Field Level Encryption Options
    The full namespace (``<database>.<collection>``) of the collection 
    used as a key vault for :ref:`manual-csfle-feature`. 
    :option:`--keyVaultNamespace` is required for enabling client-side 
-   field level encryption. for the :program:`mongosh` shell session. 
+   field level encryption for the :program:`mongosh` shell session. 
    :program:`mongosh` creates the specified namespace if it does not
    exist.
 


### PR DESCRIPTION
## DESCRIPTION

Fixed typo on options page

## STAGING

https://preview-mongodbgmillermdb.gatsbyjs.io/mongodb-shell/DOCSP-42673-typo-options/reference/options/#:~:text=client-side%20field%20level%20encryption.%20for%20the

## JIRA

https://jira.mongodb.org/browse/DOCSP-42673

## BUILD LOG

https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=66da15a9f062608452cf95c8

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)