### PR TITLE
DOCSP-44183-free-monitoring-redirect

### DIFF
--- a/config/redirects
+++ b/config/redirects
@@ -1,0 +1,4 @@
+define: base https://www.mongodb.com/docs/mongodb-shell
+
+# DOCSP-44183 - Redirect old free monitoring page
+raw: docs/mongodb-shell/free-monitoring -> ${base}/


### PR DESCRIPTION
## DESCRIPTION

Add a redirect from https://www.mongodb.com/docs/mongodb-shell/free-monitoring/ to the shell docs landing page.

Output for `mut-redirects config/redirects`:
             
`Redirect 301 /docs/mongodb-shell/free-monitoring https://www.mongodb.com/docs/mongodb-shell/`

## STAGING

N/A

## JIRA

https://jira.mongodb.org/browse/DOCSP-44183

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)