### PR TITLE
DOCSP-44585-double-type

### DIFF
--- a/source/reference/data-types.txt
+++ b/source/reference/data-types.txt
@@ -71,17 +71,17 @@ explicitly specify a double:
       db.types.insertOne(
          {
             "_id": 2,
-            "value": Double("1"),
+            "value": Double(1),
             "expectedType": "Double" 
          }
       )
 
 .. note:: 
 
-   If a number can be converted to a 32-bit integer, ``mongosh`` will store it 
-   as ``Int32``. If not, ``mongosh`` defaults to storing the number as a 
-   ``Double``. Numerical values that are stored as ``Int32`` in ``mongosh`` 
-   would have been stored by default as ``Double`` in the ``mongo`` shell.
+   If field's value is a number that can be converted to a 32-bit integer, 
+   ``mongosh`` will store it as ``Int32``. If not, ``mongosh`` defaults to 
+   storing the number as a ``Double``. To specify the value type, use the 
+   ``Double()`` or ``Int32()`` constructors. 
 
 .. _shell-type-int:
 
@@ -96,7 +96,7 @@ explicitly specify 32-bit integers.
       db.types.insertOne(
          {
              "_id": 1,
-             "value": Int32("1"),
+             "value": Int32(1),
              "expectedType": "Int32" 
          }
       )
@@ -120,7 +120,7 @@ explicitly specify a 64-bit integer.
       db.types.insertOne(
          {
             "_id": 3,
-            "value": Long("1"),
+            "value": Long(1),
             "expectedType": "Long" 
          }
       )

--- a/source/reference/data-types.txt
+++ b/source/reference/data-types.txt
@@ -60,16 +60,33 @@ Starting in  1.8.0, the ``ObjectId`` wrapper no longer accepts:
 
    :method:`ObjectId` 
 
+Double 
+------
+
+The :node-api:`Double() <Double.html>` constructor can be used to
+explicitly specify a Double:
+
+.. code-block:: javascript
+
+      db.types.insertOne(
+         {
+            "_id": 2,
+            "value": Double("1"),
+            "expectedType": "Double" 
+         }
+      )
+
+.. note:: 
+
+   If a number can be converted to a 32-bit integer, ``mongosh`` will store it 
+   as ``Int32``. If not, ``mongosh`` defaults to storing the number as a 
+   ``Double``. Numerical values that are stored as ``Int32`` in ``mongosh`` 
+   would have been stored by default as ``Double`` in the ``mongo`` shell.
+
 .. _shell-type-int:
 
 Int32
 -----
-
-If a number can be converted to a 32-bit integer, ``mongosh`` will
-store it as ``Int32``. If not, ``mongosh`` defaults to storing the
-number as a ``Double``. Numerical values that are stored as ``Int32``
-in ``mongosh`` would have been stored by default as ``Double`` in the
-``mongo`` shell.
 
 The :node-api:`Int32() <Int32.html>` constructor can be used to
 explicitly specify 32-bit integers.

--- a/source/reference/data-types.txt
+++ b/source/reference/data-types.txt
@@ -64,7 +64,7 @@ Double
 ------
 
 The :node-api:`Double() <Double.html>` constructor can be used to
-explicitly specify a Double:
+explicitly specify a double:
 
 .. code-block:: javascript
 


### PR DESCRIPTION
## DESCRIPTION
- Document `Double` type in `mongosh`
  - moved paragraph on default number type being int vs. double to a note between the Double and Integer sections for visibility with both sections.

## STAGING
https://deploy-preview-362--docs-mongodb-shell.netlify.app/reference/data-types/#double

## JIRA
https://jira.mongodb.org/browse/DOCSP-44585


## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)