### PR TITLE
DOCSP-45058-mongosh-undefined-behavior

### DIFF
--- a/source/reference/compatibility.txt
+++ b/source/reference/compatibility.txt
@@ -202,6 +202,37 @@ in ``mongosh`` better align with the types used by the MongoDB Drivers.
    For more information on managing types, refer to the
    :manual:`schema validation overview </core/schema-validation>`.
 
+Undefined Values
+----------------
+
+The undefined BSON type is deprecated <https://bsonspec.org/spec.html>__ in
+:binary:`bin.mongosh`. If you insert a document with the undefined BSON type in
+:binary:`bin.mongosh`, your deployment stores a null value. To create `undefined` 
+fields in your document, use the legacy :binary:`~bin.mongo` shell.
+
+For example, consider running the same code to insert a document in both
+:binary:`bin.mongosh` and in the legacy :binary:`~bin.mongo` shell:
+
+.. code-block:: javascript
+
+   db.people.insertOne( { name : "Sally", age : undefined } )
+
+When you run this code to insert a document with the undefined BSON type in
+:binary:`bin.mongosh`, the shell inserts the following document: 
+
+.. code-block:: javascript
+   "copyable: false
+
+   { name : "Sally", age : null }
+
+However, when you run the same code to insert a document with the undefined BSON type in
+the legacy :binary:`~bin.mongo` shell, the shell inserts the following document: 
+
+.. code-block:: javascript
+   "copyable: false
+
+   { name : "Sally", age : undefined }
+
 Object Quoting Behavior
 -----------------------
 

--- a/source/reference/compatibility.txt
+++ b/source/reference/compatibility.txt
@@ -208,7 +208,8 @@ Undefined Values
 The undefined BSON type is `deprecated <https://bsonspec.org/spec.html>`__ in
 :binary:`bin.mongosh`. If you insert a document with the undefined BSON type in
 :binary:`bin.mongosh`, your deployment replaces the undefined value in your 
-document with the BSON null value.
+document with the BSON null value. There is no supported way of inserting undefined
+values into your database using :binary:`bin.mongosh`.
 
 For example, consider running the same code to insert a document in both
 :binary:`bin.mongosh` and in the legacy :binary:`~bin.mongo` shell:

--- a/source/reference/compatibility.txt
+++ b/source/reference/compatibility.txt
@@ -208,7 +208,7 @@ Undefined Values
 The undefined BSON type is `deprecated <https://bsonspec.org/spec.html>`__ in
 :binary:`bin.mongosh`. If you insert a document with the undefined BSON type in
 :binary:`bin.mongosh`, your deployment stores a null value. To create undefined
-fields in your document, use the legacy :binary:`~bin.mongo` shell.
+fields in your documents, use the legacy :binary:`~bin.mongo` shell.
 
 For example, consider running the same code to insert a document in both
 :binary:`bin.mongosh` and in the legacy :binary:`~bin.mongo` shell:

--- a/source/reference/compatibility.txt
+++ b/source/reference/compatibility.txt
@@ -206,33 +206,25 @@ Undefined Values
 ----------------
 
 The undefined BSON type is `deprecated <https://bsonspec.org/spec.html>`__ in
-:binary:`bin.mongosh`. If you insert a document with the undefined BSON type in
+:binary:`bin.mongosh`. If you insert a document with the undefined JS type in
 :binary:`bin.mongosh`, your deployment replaces the undefined value in your 
 document with the BSON null value. There is no supported way of inserting undefined
 values into your database using :binary:`bin.mongosh`.
 
-For example, consider running the same code to insert a document in both
-:binary:`bin.mongosh` and in the legacy :binary:`~bin.mongo` shell:
+For example, consider running the same code to insert a document in
+:binary:`bin.mongosh`:
 
 .. code-block:: javascript
 
    db.people.insertOne( { name : "Sally", age : undefined } )
 
-When you run this code to insert a document with the undefined BSON type in
-:binary:`bin.mongosh`, the shell inserts the following document: 
+When you run this code in :binary:`bin.mongosh`, the shell inserts 
+the following document: 
 
 .. code-block:: javascript
    "copyable: false
 
    { name : "Sally", age : null }
-
-However, when you run the same code to insert a document with the undefined BSON type in
-the legacy :binary:`~bin.mongo` shell, the shell inserts the following document: 
-
-.. code-block:: javascript
-   "copyable: false
-
-   { name : "Sally", age : undefined }
 
 Object Quoting Behavior
 -----------------------

--- a/source/reference/compatibility.txt
+++ b/source/reference/compatibility.txt
@@ -205,9 +205,9 @@ in ``mongosh`` better align with the types used by the MongoDB Drivers.
 Undefined Values
 ----------------
 
-The undefined BSON type is deprecated <https://bsonspec.org/spec.html>__ in
+The undefined BSON type is `deprecated<https://bsonspec.org/spec.html>`__ in
 :binary:`bin.mongosh`. If you insert a document with the undefined BSON type in
-:binary:`bin.mongosh`, your deployment stores a null value. To create `undefined` 
+:binary:`bin.mongosh`, your deployment stores a null value. To create undefined
 fields in your document, use the legacy :binary:`~bin.mongo` shell.
 
 For example, consider running the same code to insert a document in both

--- a/source/reference/compatibility.txt
+++ b/source/reference/compatibility.txt
@@ -207,8 +207,8 @@ Undefined Values
 
 The undefined BSON type is `deprecated <https://bsonspec.org/spec.html>`__ in
 :binary:`bin.mongosh`. If you insert a document with the undefined BSON type in
-:binary:`bin.mongosh`, your deployment stores a null value. To create undefined
-fields in your documents, use the legacy :binary:`~bin.mongo` shell.
+:binary:`bin.mongosh`, your deployment replaces the undefined value in your 
+document with the BSON null value.
 
 For example, consider running the same code to insert a document in both
 :binary:`bin.mongosh` and in the legacy :binary:`~bin.mongo` shell:

--- a/source/reference/compatibility.txt
+++ b/source/reference/compatibility.txt
@@ -205,7 +205,7 @@ in ``mongosh`` better align with the types used by the MongoDB Drivers.
 Undefined Values
 ----------------
 
-The undefined BSON type is `deprecated<https://bsonspec.org/spec.html>`__ in
+The undefined BSON type is `deprecated <https://bsonspec.org/spec.html>`__ in
 :binary:`bin.mongosh`. If you insert a document with the undefined BSON type in
 :binary:`bin.mongosh`, your deployment stores a null value. To create undefined
 fields in your document, use the legacy :binary:`~bin.mongo` shell.

--- a/source/reference/compatibility.txt
+++ b/source/reference/compatibility.txt
@@ -211,7 +211,7 @@ The undefined BSON type is `deprecated <https://bsonspec.org/spec.html>`__ in
 document with the BSON null value. There is no supported way of inserting undefined
 values into your database using :binary:`bin.mongosh`.
 
-For example, consider running the same code to insert a document in
+For example, consider running the following code to insert a document in
 :binary:`bin.mongosh`:
 
 .. code-block:: javascript


### PR DESCRIPTION
## DESCRIPTION
[DOCSP-44560](https://jira.mongodb.org/browse/DOCSP-44560) notes that `mongosh` converts undefined to null during write operations, unlike the legacy `mongo` shell; this is not properly documented in the mongosh docs, so this PR adds this info to the [Compatibility Changes w/ Legacy `mongo` shell page](https://www.mongodb.com/docs/mongodb-shell/reference/compatibility/#compatibility-changes-with-legacy-mongo-shell)

## STAGING
https://deploy-preview-364--docs-mongodb-shell.netlify.app/reference/compatibility/#undefined-values

## JIRA
https://jira.mongodb.org/browse/DOCSP-45058

## BUILD LOG


## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)