### PR TITLE
DOCSP-45255-mongosh-compatibility-changes-clarification

### DIFF
--- a/source/reference/compatibility.txt
+++ b/source/reference/compatibility.txt
@@ -206,7 +206,7 @@ Undefined Values
 ----------------
 
 The undefined BSON type is `deprecated <https://bsonspec.org/spec.html>`__. 
-If you insert a document with the undefined JS type in
+If you try to insert a document with the undefined JS type in
 ``mongosh``, your deployment replaces the undefined value in your 
 document with the BSON null value. There is no supported way of inserting undefined
 values into your database using ``mongosh``.

--- a/source/reference/compatibility.txt
+++ b/source/reference/compatibility.txt
@@ -207,18 +207,18 @@ Undefined Values
 
 The undefined BSON type is `deprecated <https://bsonspec.org/spec.html>`__. 
 If you insert a document with the undefined JS type in
-:binary:`bin.mongosh`, your deployment replaces the undefined value in your 
+``mongosh``, your deployment replaces the undefined value in your 
 document with the BSON null value. There is no supported way of inserting undefined
-values into your database using :binary:`bin.mongosh`.
+values into your database using ``mongosh``.
 
 For example, consider running the following code to insert a document in
-:binary:`bin.mongosh`:
+``mongosh``:
 
 .. code-block:: javascript
 
    db.people.insertOne( { name : "Sally", age : undefined } )
 
-When you run this code in :binary:`bin.mongosh`, the shell inserts 
+When you run this code in ``mongosh``, the shell inserts 
 the following document: 
 
 .. code-block:: javascript
@@ -228,7 +228,7 @@ the following document:
 
 ``mongosh`` represents any BSON undefined values stored using other tools, such as 
 the `Go Driver <https://www.mongodb.com/docs/drivers/go/current/>`__ or the 
-legacy :binary:`mongo` shell, as null.
+legacy ``mongo`` shell, as null.
 
 Object Quoting Behavior
 -----------------------

--- a/source/reference/compatibility.txt
+++ b/source/reference/compatibility.txt
@@ -205,8 +205,8 @@ in ``mongosh`` better align with the types used by the MongoDB Drivers.
 Undefined Values
 ----------------
 
-The undefined BSON type is `deprecated <https://bsonspec.org/spec.html>`__ in
-:binary:`bin.mongosh`. If you insert a document with the undefined JS type in
+The undefined BSON type is `deprecated <https://bsonspec.org/spec.html>`__. 
+If you insert a document with the undefined JS type in
 :binary:`bin.mongosh`, your deployment replaces the undefined value in your 
 document with the BSON null value. There is no supported way of inserting undefined
 values into your database using :binary:`bin.mongosh`.
@@ -225,6 +225,10 @@ the following document:
    "copyable: false
 
    { name : "Sally", age : null }
+
+``mongosh`` represents any BSON undefined values stored using other tools, such as 
+the `Go Driver <https://www.mongodb.com/docs/drivers/go/current/>`__ or the 
+legacy :binary:`mongo` shell, as null.
 
 Object Quoting Behavior
 -----------------------


### PR DESCRIPTION
## DESCRIPTION

Couple changes made in the[ "Undefined Values"|https://www.mongodb.com/docs/mongodb-shell/reference/compatibility/#undefined-values] section of the "Compatibility Changes with Legacy `mongo` Shell page: 

1. Section mentions that `mongosh` represents any stored BSON value as null. So if you’ve stored a BSON undefined value with some other tool—e.g., Go’s driver or the mongo shell—then you fetch that document with mongosh, you’ll see null where the actual stored document has undefined. 
2. Mentions that BSON undefined is deprecated everywhere, not just in `mongosh`. 


## STAGING
https://deploy-preview-365--docs-mongodb-shell.netlify.app/reference/compatibility/#undefined-values

## JIRA

https://jira.mongodb.org/browse/DOCSP-45255


## BUILD LOG


## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)