### PR TITLE
DOCSP-46185 Adds 2.3.8 release notes

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -17,7 +17,7 @@ toc_landing_pages = ["/install",
 
 [constants]
 
-version = "2.3.2"
+version = "2.3.8"
 mdb-version = "8.0"
 pgp-version = "{+mdb-version+}"
 atlas = "MongoDB Atlas"

--- a/source/changelog.txt
+++ b/source/changelog.txt
@@ -12,6 +12,16 @@ Release Notes
    :depth: 1
    :class: singlecol
 
+v2.3.8
+------
+
+*Released January 6, 2025*
+
+Contains internal enhancements and improvements.
+
+`Full release notes available on JIRA 
+<https://jira.mongodb.org/secure/ReleaseNote.jspa?projectId=17381&version=41730>`__.
+
 v2.3.4
 ------
 


### PR DESCRIPTION
## DESCRIPTION
Adds 2.3.8 release notes. Per JIRA release ticket, no explicit release notes required (internal only).

## STAGING
https://deploy-preview-375--docs-mongodb-shell.netlify.app/changelog/#v2.3.8

## JIRA
https://jira.mongodb.org/browse/DOCSP-46185


## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)