### PR TITLE
DOCSP-47888-custom-log-location

### DIFF
--- a/snooty.toml
+++ b/snooty.toml
@@ -12,7 +12,8 @@ toc_landing_pages = ["/install",
                      "/snippets",
                      "/configure-mongosh",
                      "/reference/configure-shell-settings",
-                     "/reference/ejson"
+                     "/reference/ejson",
+                     "/logs"
                     ]
 
 [constants]

--- a/source/includes/list-table-shell-properties.rst
+++ b/source/includes/list-table-shell-properties.rst
@@ -53,6 +53,12 @@
        to ``Infinity`` (the javascript object) prints all nested
        objects to their full depth. 
 
+   * - ``logLocation``
+     - string
+     - Depends on your operating system. See :ref:`mdb-shell-view-logs`.
+     - Directory where MongoDB Shell writes log files. Specify an
+       absolute filepath. See :ref:`mongosh-log-location`.
+
    * - ``redactHistory``
      - string
      - ``remove``

--- a/source/logs.txt
+++ b/source/logs.txt
@@ -60,3 +60,8 @@ Log Retention
 
 ``mongosh`` retains up to 100 log files for 30 days. ``mongosh``
 automatically deletes log files older than 30 days.
+
+.. toctree::
+   :titlesonly:
+
+   Specify Log Location <logs/location> 

--- a/source/logs.txt
+++ b/source/logs.txt
@@ -30,6 +30,9 @@ View |mdb-shell| Logs
 
 .. include:: /includes/steps/view-logs.rst
 
+To change where MongoDB Shell writes logs, see
+:ref:`mongosh-log-location`.
+
 .. _mdb-shell-command-history:
 
 View |mdb-shell| Command History

--- a/source/logs.txt
+++ b/source/logs.txt
@@ -30,8 +30,10 @@ View |mdb-shell| Logs
 
 .. include:: /includes/steps/view-logs.rst
 
-To change where MongoDB Shell writes logs, see
-:ref:`mongosh-log-location`.
+.. tip::
+  
+   To change where MongoDB Shell writes logs, see
+   :ref:`mongosh-log-location`.
 
 .. _mdb-shell-command-history:
 

--- a/source/logs/location.txt
+++ b/source/logs/location.txt
@@ -68,8 +68,6 @@ setting to ``/path/to/log/directory``:
 
       Setting "logLocation" has been changed
 
-Test
-
 Modify Log Location with a Configuration File
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/logs/location.txt
+++ b/source/logs/location.txt
@@ -55,16 +55,18 @@ Modify Log Location with the API
 The following command uses the config API to set the ``logLocation``
 setting to ``/path/to/log/directory``:
 
-.. code-block:: javascript
+.. io-code-block::
+   :copyable: true
 
-   config.set("logLocation", "/path/to/log/directory")
+   .. input::
+      :language: javascript
 
-Output:
+      config.set("logLocation", "/path/to/log/directory")
 
-.. code-block:: javascript
-   :copyable: false
+   .. output::
+      :language: javascript
 
-   Setting "logLocation" has been changed
+      Setting "logLocation" has been changed
 
 Modify Log Location with a Configuration File
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/logs/location.txt
+++ b/source/logs/location.txt
@@ -41,7 +41,7 @@ start after you change the log file location use the updated location.
 Steps
 -----
 
-To change the default log location, modify the ``logLocation``
+To change the log file location, modify the ``logLocation``
 configuration option. You can modify configuration options with the
 configuration API or a configuration file.
 

--- a/source/logs/location.txt
+++ b/source/logs/location.txt
@@ -1,0 +1,7 @@
+.. _mongosh-log-location:
+
+=========================
+Specify Log File Location
+=========================
+
+You can specify where MongoDB Shell writes log files. By default, 

--- a/source/logs/location.txt
+++ b/source/logs/location.txt
@@ -4,4 +4,48 @@
 Specify Log File Location
 =========================
 
-You can specify where MongoDB Shell writes log files. By default, 
+You can specify where MongoDB Shell writes log files. By default,
+MongoDB Shell saves the log for each session to your user's
+``.mongodb/mongosh`` directory. The default directory depends on your
+operating system:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Operating System
+     - Default Log Location
+   * - macOS and Linux
+     - ``~/.mongodb/mongosh/<LogID>_log``
+   * - Windows
+     - ``%UserProfile%/AppData/Local/mongodb/mongosh/<LogID>_log``
+
+Steps
+-----
+
+To change the default log location, modify the ``logLocation``
+configuration option. You can modify configuration options with either
+the configuration API or a configuration file.
+
+.. important::
+
+   Specify ``logLocation`` as an absolute filepath.
+
+Modify Log Location with the API
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following command sets the ``logLocation`` setting to
+``/path/to/log/directory``:
+
+.. code-block:: javascript
+
+   config.set("logLocation", "/path/to/log/directory")
+
+Output:
+
+.. code-block:: javascript
+   :copyable: false
+
+   Setting "logLocation" has been changed
+
+Modify Log Location with a Configuration File
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/logs/location.txt
+++ b/source/logs/location.txt
@@ -19,6 +19,21 @@ operating system:
    * - Windows
      - ``%UserProfile%/AppData/Local/mongodb/mongosh/<LogID>_log``
 
+About this Task
+---------------
+
+To view the current log file location, use the :ref:`config API
+<configure-settings-api>` to return the ``logLocation`` value:
+
+.. code-block:: javascript
+
+   config.get("logLocation")
+
+After you modify your log file location, your current MongoDB Shell
+session continues to use the previous log file location. MongoDB Shell
+sessions that start after you change the log file location use the
+updated location.
+
 Steps
 -----
 
@@ -33,8 +48,8 @@ the configuration API or a configuration file.
 Modify Log Location with the API
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The following command sets the ``logLocation`` setting to
-``/path/to/log/directory``:
+The following command uses the config API to set the ``logLocation``
+setting to ``/path/to/log/directory``:
 
 .. code-block:: javascript
 
@@ -49,3 +64,11 @@ Output:
 
 Modify Log Location with a Configuration File
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following :ref:`configuration file <configure-settings-global>` sets
+the ``logLocation`` setting to ``/path/to/log/directory``:
+
+.. code-block:: yaml
+
+   mongosh:
+     logLocation: "/path/to/log/directory"

--- a/source/logs/location.txt
+++ b/source/logs/location.txt
@@ -10,7 +10,7 @@ Specify Log File Location
    :depth: 1
    :class: singlecol
 
-TEST You can specify where MongoDB Shell writes log files. By default,
+You can specify where MongoDB Shell writes log files. By default,
 MongoDB Shell saves the log for each session to your user's
 ``.mongodb/mongosh`` directory, which depends on your operating system:
 

--- a/source/logs/location.txt
+++ b/source/logs/location.txt
@@ -10,7 +10,7 @@ Specify Log File Location
    :depth: 1
    :class: singlecol
 
-You can specify where MongoDB Shell writes log files. By default,
+TEST You can specify where MongoDB Shell writes log files. By default,
 MongoDB Shell saves the log for each session to your user's
 ``.mongodb/mongosh`` directory, which depends on your operating system:
 
@@ -67,6 +67,8 @@ setting to ``/path/to/log/directory``:
       :language: javascript
 
       Setting "logLocation" has been changed
+
+Test
 
 Modify Log Location with a Configuration File
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/logs/location.txt
+++ b/source/logs/location.txt
@@ -6,8 +6,7 @@ Specify Log File Location
 
 You can specify where MongoDB Shell writes log files. By default,
 MongoDB Shell saves the log for each session to your user's
-``.mongodb/mongosh`` directory. The default directory depends on your
-operating system:
+``.mongodb/mongosh`` directory, which depends on your operating system:
 
 .. list-table::
    :header-rows: 1

--- a/source/logs/location.txt
+++ b/source/logs/location.txt
@@ -29,9 +29,8 @@ To view the current log file location, use the :ref:`config API
    config.get("logLocation")
 
 After you modify your log file location, your current MongoDB Shell
-session continues to use the previous log file location. MongoDB Shell
-sessions that start after you change the log file location use the
-updated location.
+session continues to use the previous log file location. Sessions that
+start after you change the log file location use the updated location.
 
 Steps
 -----

--- a/source/logs/location.txt
+++ b/source/logs/location.txt
@@ -38,6 +38,19 @@ After you modify your log file location, your current MongoDB Shell
 session continues to use the previous log file location. Sessions that
 start after you change the log file location use the updated location.
 
+Log File Names
+~~~~~~~~~~~~~~
+
+If you modify the default log file location, log files have a
+``mongosh_`` prefix before the session ID. For example, the log for
+session ID ``67be0c0eb6227e211a1979e8`` is saved as
+``mongosh_67be0c0eb6227e211a1979e8_log``.
+
+If you use the default log file location, the file name does not include
+the ``mongosh_`` prefix. For example, the log for session ID
+``67be0c0eb6227e211a1979e8`` is saved as
+``67be0c0eb6227e211a1979e8_log``.
+
 Steps
 -----
 

--- a/source/logs/location.txt
+++ b/source/logs/location.txt
@@ -4,6 +4,12 @@
 Specify Log File Location
 =========================
 
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
 You can specify where MongoDB Shell writes log files. By default,
 MongoDB Shell saves the log for each session to your user's
 ``.mongodb/mongosh`` directory, which depends on your operating system:
@@ -36,8 +42,8 @@ Steps
 -----
 
 To change the default log location, modify the ``logLocation``
-configuration option. You can modify configuration options with either
-the configuration API or a configuration file.
+configuration option. You can modify configuration options with the
+configuration API or a configuration file.
 
 .. important::
 


### PR DESCRIPTION
## DESCRIPTION

Users can now specify a custom location for shell log files.

## STAGING

- [Specify Log File Location](https://deploy-preview-379--docs-mongodb-shell.netlify.app/logs/location/)
- [Settings Table](https://deploy-preview-379--docs-mongodb-shell.netlify.app/reference/configure-shell-settings/#configurable-settings)

## JIRA

https://jira.mongodb.org/browse/DOCSP-47888

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)