### PR TITLE
DOCSP-47856 Added CVE numbers and links

### DIFF
--- a/source/changelog.txt
+++ b/source/changelog.txt
@@ -78,7 +78,10 @@ v2.3.9
   For more information, see the  `January 21, 2025 Node.js security release \
   <https://nodejs.org/en/blog/release/v20.18.2>`__.
 
-- Stricter validation of user input to address vulnerabilities.
+- Stricter validation of user input to address 
+  `CVE 1691 <https://nvd.nist.gov/vuln/detail/CVE-2025-1691>`_, 
+  `CVE 1692 <https://nvd.nist.gov/vuln/detail/CVE-2025-1692>`_, 
+  and `CVE 1693 <https://nvd.nist.gov/vuln/detail/CVE-2025-1693>`__.
 
 New features released in this version:
 

--- a/source/changelog.txt
+++ b/source/changelog.txt
@@ -79,8 +79,8 @@ v2.3.9
   <https://nodejs.org/en/blog/release/v20.18.2>`__.
 
 - Stricter validation of user input to address 
-  `CVE 1691 <https://nvd.nist.gov/vuln/detail/CVE-2025-1691>`_, 
-  `CVE 1692 <https://nvd.nist.gov/vuln/detail/CVE-2025-1692>`_, 
+  `CVE 1691 <https://nvd.nist.gov/vuln/detail/CVE-2025-1691>`__, 
+  `CVE 1692 <https://nvd.nist.gov/vuln/detail/CVE-2025-1692>`__, 
   and `CVE 1693 <https://nvd.nist.gov/vuln/detail/CVE-2025-1693>`__.
 
 New features released in this version:

--- a/source/changelog.txt
+++ b/source/changelog.txt
@@ -79,9 +79,9 @@ v2.3.9
   <https://nodejs.org/en/blog/release/v20.18.2>`__.
 
 - Stricter validation of user input to address 
-  `CVE 1691 <https://nvd.nist.gov/vuln/detail/CVE-2025-1691>`__, 
-  `CVE 1692 <https://nvd.nist.gov/vuln/detail/CVE-2025-1692>`__, 
-  and `CVE 1693 <https://nvd.nist.gov/vuln/detail/CVE-2025-1693>`__.
+  `CVE-2025-1691 <https://nvd.nist.gov/vuln/detail/CVE-2025-1691>`__, 
+  `CVE-2025-1692 <https://nvd.nist.gov/vuln/detail/CVE-2025-1692>`__, 
+  and `CVE-2025-1693 <https://nvd.nist.gov/vuln/detail/CVE-2025-1693>`__.
 
 New features released in this version:
 


### PR DESCRIPTION
## DESCRIPTION

- Adds CVE numbers and links for the 2.3.9 release notes

## STAGING
[Release Notes: 2.3.9](https://deploy-preview-380--docs-mongodb-shell.netlify.app/changelog/#v2.3.9)
NVD CVEs: [1691](https://nvd.nist.gov/vuln/detail/CVE-2025-1691), [1692](https://nvd.nist.gov/vuln/detail/CVE-2025-1692), [1693](https://nvd.nist.gov/vuln/detail/CVE-2025-1693)

## JIRA
https://jira.mongodb.org/browse/DOCSP-47856

## BUILD LOG


## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working? ~~The NVD links aren't yet live. CVE.org shows the pages as reserved and pending. Waiting on either/both to update prior to merging this.~~

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)