### PR TITLE
DOCSP-16967-inconsistent-connection-string-attribute-description

### DIFF
--- a/source/connect.txt
+++ b/source/connect.txt
@@ -357,7 +357,7 @@ following command:
 
     mongosh "mongodb://localhost:27017/qa"
 
-The database attribute in the connection string can also take `<defaultAuthDB>`, 
+The database attribute in the connection string can also take ``<defaultauthdb>``, 
 which specifies the authentication database to use if the connection string 
 includes `username:password@` authentication credentials but the :urioption:`authSource`
 option is unspecified. For more information, see :ref:`connections-standard-connection-string-format`.

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -348,7 +348,7 @@ Connect to a Specific Database
 To connect to a specific default database, specify a database in your
 :manual:`connection string URI path </reference/connection-string/>`. If
 you do not specify a database in your URI path, you connect to the
-``admin`` database.
+``test`` database.
 
 For example, to connect to a database called ``qa`` on localhost, run the
 following command:

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -346,9 +346,9 @@ Connect to a Specific Database
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To connect to a specific default database, specify a database in your
-:manual:`connection string URI path </reference/connection-string/>`. If
-you do not specify a database in your URI path, you connect to the
-``test`` database.
+:manual:`connection string URI path </reference/connection-string/>`.
+If unspecified by the connection string, the default database
+is the ``test`` database.
 
 For example, to connect to a database called ``qa`` on localhost, run the
 following command:
@@ -357,11 +357,12 @@ following command:
 
     mongosh "mongodb://localhost:27017/qa"
 
-You can also specify an authentication database in your connection 
-string using the :urioption:`authSource` connection option to verify 
-your user identity and credentials against. If :urioption:`authSource` is 
-unspecified, it defaults to the default database specified in the connection
-string. If both :urioption:`authSource` and the default database are unspecified, 
+You can specify the authentication database in your connection string
+using the :urioption:`authSource` connection option. If specified, the
+client uses this database to verify your user identity and credentials. 
+If :urioption:`authSource` is unspecified, it defaults to the default 
+database specified in the connection string. If both :urioption:`authSource` 
+and the default database are unspecified, 
 :urioption:`authSource` defaults to the ``admin`` database.
 
 The following connection string sets the default database to ``myDefaultDB``

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -359,7 +359,7 @@ following command:
 
 The database attribute in the connection string can also take ``<defaultauthdb>``, 
 which specifies the authentication database to use if the connection string 
-includes `username:password@` authentication credentials but the :urioption:`authSource`
+includes ``username:password@`` authentication credentials but the :urioption:`authSource`
 option is unspecified. For more information, see :ref:`connections-standard-connection-string-format`.
 
 Proxy Settings

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -345,10 +345,10 @@ To connect to a deployment using TLS, you can either:
 Connect to a Specific Database
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To connect to a specific database, specify a database in your
+To connect to a specific default database, specify a database in your
 :manual:`connection string URI path </reference/connection-string/>`. If
 you do not specify a database in your URI path, you connect to the
-``test`` database.
+``admin`` database.
 
 For example, to connect to a database called ``qa`` on localhost, run the
 following command:
@@ -357,10 +357,19 @@ following command:
 
     mongosh "mongodb://localhost:27017/qa"
 
-The database attribute in the connection string can also take ``<defaultauthdb>``, 
-which specifies the authentication database to use if the connection string 
-includes ``username:password@`` authentication credentials but the :urioption:`authSource`
-option is unspecified. For more information, see :ref:`connections-standard-connection-string-format`.
+You can also specify an authentication database in your connection 
+string using the :urioption:`authSource` connection option to verify 
+your user identity and credentials against. If :urioption:`authSource` is 
+unspecified, it defaults to the default database specified in the connection
+string. If both :urioption:`authSource` and the default database are unspecified, 
+:urioption:`authSource` defaults to the ``admin`` database.
+
+The following connection string sets the default database to ``myDefaultDB``
+and the authentication database to ``admin``:
+
+.. code-block:: bash
+
+   mongodb://myDatabaseUser:D1fficultP%40ssw0rd@mongodb0.example.com:27017/myDefaultDB?authSource=admin
 
 Proxy Settings
 ~~~~~~~~~~~~~~

--- a/source/connect.txt
+++ b/source/connect.txt
@@ -355,7 +355,12 @@ following command:
 
 .. code-block:: sh
 
-    mongosh "mongodb://localhost:27017/qa" 
+    mongosh "mongodb://localhost:27017/qa"
+
+The database attribute in the connection string can also take `<defaultAuthDB>`, 
+which specifies the authentication database to use if the connection string 
+includes `username:password@` authentication credentials but the :urioption:`authSource`
+option is unspecified. For more information, see :ref:`connections-standard-connection-string-format`.
 
 Proxy Settings
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
## DESCRIPTION
Add diff behaviors of database attributes in connection strings for both manual and mongosh. This PR handles the changes on Mongo Shell ([connect to a deploymet page](https://www.mongodb.com/docs/mongodb-shell/connect/#connect-to-a-specific-database))

Manual PR: https://github.com/10gen/docs-mongodb-internal/pull/11259

## STAGING
https://deploy-preview-385--docs-mongodb-shell.netlify.app/connect/#connect-to-a-specific-database

## JIRA
https://jira.mongodb.org/browse/DOCS-16967

## BUILD LOG


## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)