### PR TITLE
DOCSP-47901-refactor-logging-landing-page

### DIFF
--- a/source/includes/admonitions/note-redact-credentials-command-history.rst
+++ b/source/includes/admonitions/note-redact-credentials-command-history.rst
@@ -1,5 +1,2 @@
-.. note::
-
-   The |mdb-shell| redacts credentials from the :ref:`command history
-   <mdb-shell-command-history>` and the :ref:`logs
-   <mdb-shell-view-logs>`.
+The |mdb-shell| redacts credentials from the :ref:`command history
+<mdb-shell-command-history>` and the :ref:`logs <mdb-shell-view-logs>`.

--- a/source/logs.txt
+++ b/source/logs.txt
@@ -17,6 +17,9 @@ actions performed in the |mdb-shell|.
 Get Started
 -----------
 
+You can view or tail the logs for a |mdb-shell| session based on its log
+ID.
+
 To learn how to view and customize |mdb-shell| logs, see these pages:
 
 - :ref:`mdb-shell-view-logs`
@@ -31,21 +34,21 @@ Details
 
 See the following details about |mdb-shell| logging behavior:
 
-Log Format
-~~~~~~~~~~
+Format
+~~~~~~
 
 The |mdb-shell| uses `Newline delimited JSON
-<https://github.com/ndjson/ndjson-spec>`__ to store session logs. The
-format used for |mdb-shell| logs matches the MongoDB server log format.
-For details, see :ref:`log-messages-ref`. 
+<https://github.com/ndjson/ndjson-spec>`__ to store session logs, which
+is the same log format used for :ref:`MongoDB server logs
+<log-messages-ref>`.
 
-You can view or tail the logs for a |mdb-shell| session based on its
-log ID.
+Redaction
+~~~~~~~~~
 
 .. include:: /includes/admonitions/note-redact-credentials-command-history.rst
 
-Log Retention
-~~~~~~~~~~~~~
+Retention
+~~~~~~~~~
 
 By default, the |mdb-shell| retains up to 100 log files, and individual
 log files are retained for 30 days. To customize log file retention, see

--- a/source/logs.txt
+++ b/source/logs.txt
@@ -47,9 +47,9 @@ log ID.
 Log Retention
 ~~~~~~~~~~~~~
 
-By default, ``mongosh`` retains up to 100 log files for 30 days.
-``mongosh`` automatically deletes log files older than 30 days. To
-customize log file retention, see :ref:`mongosh-logs-retention`.
+By default, the |mdb-shell| retains up to 100 log files, and individual
+log files are retained for 30 days. To customize log file retention, see
+:ref:`mongosh-logs-retention`.
 
 .. toctree::
    :titlesonly:

--- a/source/logs.txt
+++ b/source/logs.txt
@@ -1,10 +1,8 @@
 .. _mdb-shell-logs:
 
-===================
-Retrieve Shell Logs
-===================
-
-.. default-domain:: mongodb
+==========
+Shell Logs
+==========
 
 .. contents:: On this page
    :local:
@@ -12,56 +10,42 @@ Retrieve Shell Logs
    :depth: 1
    :class: singlecol
 
-|mdb-shell| uses `Newline delimited JSON
-<https://github.com/ndjson/ndjson-spec>`__ to store session logs.
-Starting in :binary:`mongosh` version 1.0.5, the log |mdb-shell| format
-is updated to match the MongoDB server log format. For details, see
-:ref:`log-messages-ref`. 
+The |mdb-shell| stores a log for each session. The log contains a record
+of commands run, server connections, and other useful information about
+actions performed in the |mdb-shell|.
+
+Get Started
+-----------
+
+To learn how to view and customize |mdb-shell| logs, see these pages:
+
+- :ref:`mdb-shell-view-logs`
+- :ref:`mdb-shell-command-history`
+- :ref:`mongosh-log-location`
+- :ref:`mongosh-custom-log-entries`
+- :ref:`mongosh-log-compression`
+- :ref:`mongosh-logs-disable`
+
+Details
+-------
+
+See the following details about |mdb-shell| logging behavior:
+
+Log Format
+~~~~~~~~~~
+
+The |mdb-shell| uses `Newline delimited JSON
+<https://github.com/ndjson/ndjson-spec>`__ to store session logs. The
+format used for |mdb-shell| logs matches the MongoDB server log format.
+For details, see :ref:`log-messages-ref`. 
 
 You can view or tail the logs for a |mdb-shell| session based on its
 log ID.
 
 .. include:: /includes/admonitions/note-redact-credentials-command-history.rst
 
-.. _mdb-shell-view-logs:
-
-View |mdb-shell| Logs
----------------------
-
-.. include:: /includes/steps/view-logs.rst
-
-.. tip::
-  
-   To change where MongoDB Shell writes logs, see
-   :ref:`mongosh-log-location`.
-
-.. _mdb-shell-command-history:
-
-View |mdb-shell| Command History
---------------------------------
-
-|mdb-shell| saves a history of all commands you've run across sessions.
-When a new command is issued, it is added to the beginning of the
-history file.
-
-Open the following file in a text editor to view the |mdb-shell| command
-history:
-
-.. list-table::
-   :header-rows: 1
-   :widths: 1 2
-
-   * - Operating System
-     - Path to History File
-
-   * - macOS and Linux
-     - ``~/.mongodb/mongosh/mongosh_repl_history``
-
-   * - Windows
-     - ``%UserProfile%/.mongodb/mongosh/mongosh_repl_history``
-
 Log Retention
--------------
+~~~~~~~~~~~~~
 
 By default, ``mongosh`` retains up to 100 log files for 30 days.
 ``mongosh`` automatically deletes log files older than 30 days. To
@@ -70,6 +54,8 @@ customize log file retention, see :ref:`mongosh-logs-retention`.
 .. toctree::
    :titlesonly:
 
+   View Logs </logs/view>
+   View Command History </logs/command-history>
    Specify Log Location </logs/location> 
    Write Custom Log Entries </logs/custom-entries>
    Retention </logs/retention>

--- a/source/logs/command-history.txt
+++ b/source/logs/command-history.txt
@@ -1,0 +1,25 @@
+.. _mdb-shell-command-history:
+
+==========================
+View Shell Command History
+==========================
+
+|mdb-shell| saves a history of all commands you've run across sessions.
+When a new command is issued, it is added to the beginning of the
+history file.
+
+To view the |mdb-shell| command history, open the following file in a
+text editor:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 1 2
+
+   * - Operating System
+     - Path to History File
+
+   * - macOS and Linux
+     - ``~/.mongodb/mongosh/mongosh_repl_history``
+
+   * - Windows
+     - ``%UserProfile%/.mongodb/mongosh/mongosh_repl_history``

--- a/source/logs/command-history.txt
+++ b/source/logs/command-history.txt
@@ -10,9 +10,9 @@ View Shell Command History
    :depth: 1
    :class: singlecol
 
-|mdb-shell| saves a history of all commands you've run across sessions.
-When a new command is issued, it is added to the beginning of the
-history file.
+The |mdb-shell| saves a history of all commands you've run across
+sessions. When a new command is issued, it is added to the beginning of
+the history file.
 
 Steps
 -----

--- a/source/logs/command-history.txt
+++ b/source/logs/command-history.txt
@@ -4,9 +4,18 @@
 View Shell Command History
 ==========================
 
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
 |mdb-shell| saves a history of all commands you've run across sessions.
 When a new command is issued, it is added to the beginning of the
 history file.
+
+Steps
+-----
 
 To view the |mdb-shell| command history, open the following file in a
 text editor:

--- a/source/logs/view.txt
+++ b/source/logs/view.txt
@@ -10,6 +10,9 @@ View Shell Logs
    :depth: 1
    :class: singlecol
 
+The |mdb-shell| stores logs for each session. The default log location
+depends on your operating system.
+
 .. include:: /includes/steps/view-logs.rst
 
 .. tip::

--- a/source/logs/view.txt
+++ b/source/logs/view.txt
@@ -1,0 +1,18 @@
+.. _mdb-shell-view-logs:
+
+===============
+View Shell Logs
+===============
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+.. include:: /includes/steps/view-logs.rst
+
+.. tip::
+  
+   To change where MongoDB Shell writes logs, see
+   :ref:`mongosh-log-location`.

--- a/source/reference.txt
+++ b/source/reference.txt
@@ -13,4 +13,4 @@ Reference
    EJSON </reference/ejson>
    .mongoshrc Configuration File </mongoshrc>
    Options </reference/options>
-   Retrieve Shell Logs </logs>
+   Logs </logs>

--- a/source/write-scripts.txt
+++ b/source/write-scripts.txt
@@ -437,7 +437,9 @@ The following command connects to a MongoDB instance that is:
    this is the only way I could get it to work.
    https://docs.mongodb.com/manual/tutorial/write-scripts-for-the-mongo-shell/#opening-new-connections
 
-.. include:: /includes/admonitions/note-redact-credentials-command-history.rst
+.. note::
+   
+   .. include:: /includes/admonitions/note-redact-credentials-command-history.rst
 
 Use ``connect()`` to Connect to a MongoDB Instance
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -544,4 +546,3 @@ you do not have to edit the script to run ``portableGetUserCount.js``.
    require() versus load() </write-scripts/require-load-differences>
    Code Scoping </write-scripts/scoping>
    Considerations </write-scripts/considerations>
-


### PR DESCRIPTION
## DESCRIPTION

Refactor logging landing page to split tasks into their own pages.

## STAGING

- [Shell Logs](https://deploy-preview-389--docs-mongodb-shell.netlify.app/logs/)
- [View Shell Logs](https://deploy-preview-389--docs-mongodb-shell.netlify.app/logs/view/) (No major copy changes here. Just moving the pre-existing copy to its own task page.)
- [View Command History](https://deploy-preview-389--docs-mongodb-shell.netlify.app/logs/command-history/) (No major copy changes here. Just moving the pre-existing copy to its own task page.)

## JIRA

https://jira.mongodb.org/browse/DOCSP-47901

## BUILD LOG


## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)