### PR TITLE
[DOCSP-47795] Change batchsize description

### DIFF
--- a/source/reference/methods.txt
+++ b/source/reference/methods.txt
@@ -501,10 +501,9 @@ Cursor Methods
        client within each batch returned in a query result. By default, the initial batch
        size is the lesser of ``101`` documents or 16 mebibytes (MiB) worth of documents.
        Subsequent batches have a maximum size of 16 MiB. This option can enforce a smaller
-       limit than 16 MiB, but not a larger one. If you set ``batchSize`` to a limit that
-       results in batches larger than 16 MiB, this option has no effect and
-       :method:`~cursor.batchSize()` uses the default batch size of the lesser of ``101``
-       documents or 16 mebibytes (MiB) worth of documents.
+       limit than 16 MiB, but not a larger one. When set, the
+       ``batchSize`` is the lesser of ``batchSize`` documents or 16 MiB worth of
+        documents.
 
        A ``batchSize`` of ``0`` means that the cursor is established, but no documents 
        are returned in the first batch. 

--- a/source/reference/methods.txt
+++ b/source/reference/methods.txt
@@ -497,14 +497,14 @@ Cursor Methods
        .. arrayAccess
 
    * - :method:`cursor.batchSize()`
-     - Specifies the maximum number of documents MongoDB will return to the 
-       client within each batch returned in a query result. By default, 
-       the initial batch size is ``101`` documents and subsequent batches 
-       have a maximum size of 16 mebibytes (MiB). This option can enforce a 
-       smaller limit than 16 MiB, but not a larger one. If you set ``batchSize`` 
-       to a limit that results in batches larger than 16 MiB, this option 
-       has no effect and :method:`~cursor.batchSize()` uses the default 
-       batch size.
+     - Specifies the maximum number of documents MongoDB can return to the 
+       client within each batch returned in a query result. By default, the initial batch
+       size is the lesser of ``101`` documents or 16 mebibytes (MiB) worth of documents.
+       Subsequent batches have a maximum size of 16 MiB. This option can enforce a smaller
+       limit than 16 MiB, but not a larger one. If you set ``batchSize`` to a limit that
+       results in batches larger than 16 MiB, this option has no effect and
+       :method:`~cursor.batchSize()` uses the default batch size of the lesser of ``101``
+       documents or 16 mebibytes (MiB) worth of documents.
 
        A ``batchSize`` of ``0`` means that the cursor is established, but no documents 
        are returned in the first batch. 

--- a/source/reference/methods.txt
+++ b/source/reference/methods.txt
@@ -503,7 +503,7 @@ Cursor Methods
        Subsequent batches have a maximum size of 16 MiB. This option can enforce a smaller
        limit than 16 MiB, but not a larger one. When set, the
        ``batchSize`` is the lesser of ``batchSize`` documents or 16 MiB worth of
-        documents.
+       documents.
 
        A ``batchSize`` of ``0`` means that the cursor is established, but no documents 
        are returned in the first batch. 

--- a/source/reference/methods.txt
+++ b/source/reference/methods.txt
@@ -497,11 +497,11 @@ Cursor Methods
        .. arrayAccess
 
    * - :method:`cursor.batchSize()`
-     - Specifies the maximum number of documents MongoDB will return to the client 
-       within each batch returned in a query result. By default, the initial batch
-       size is ``101`` documents and subsequent batches have a maximum 
-       size of 16 mebibytes (MiB). This option can enforce a smaller
-       limit than 16 MiB, but not a larger one. If you set ``batchSize`` 
+     - Specifies the maximum number of documents MongoDB will return to the 
+       client within each batch returned in a query result. By default, 
+       the initial batch size is ``101`` documents and subsequent batches 
+       have a maximum size of 16 mebibytes (MiB). This option can enforce a 
+       smaller limit than 16 MiB, but not a larger one. If you set ``batchSize`` 
        to a limit that results in batches larger than 16 MiB, this option 
        has no effect and :method:`~cursor.batchSize()` uses the default 
        batch size.

--- a/source/reference/methods.txt
+++ b/source/reference/methods.txt
@@ -502,7 +502,9 @@ Cursor Methods
        size is ``101`` documents and subsequent batches have a maximum 
        size of 16 mebibytes (MiB). This option can enforce a smaller
        limit than 16 MiB, but not a larger one. If you set ``batchSize`` 
-       to a limit that results in batches larger than 16 MiB, this option has no effect and :method:`~cursor.batchSize()` uses the default batch size.
+       to a limit that results in batches larger than 16 MiB, this option 
+       has no effect and :method:`~cursor.batchSize()` uses the default 
+       batch size.
 
        A ``batchSize`` of ``0`` means that the cursor is established, but no documents 
        are returned in the first batch. 

--- a/source/reference/methods.txt
+++ b/source/reference/methods.txt
@@ -497,8 +497,15 @@ Cursor Methods
        .. arrayAccess
 
    * - :method:`cursor.batchSize()`
-     - Controls the number of documents MongoDB will return to the
-       client in a single network message.
+     - Specifies the maximum number of documents MongoDB will return to the client 
+       within each batch returned in a query result. By default, the initial batch 
+       size is ``101`` documents and subsequent batches have a maximum 
+       size of 16 mebibytes (MiB). This option can enforce a smaller
+       limit than 16 MiB, but not a larger one. If you set ``batchSize`` 
+       to a limit that results in batches larger than 16 MiB, this option has no effect.
+
+       A batchSize of 0 means that the cursor will be established, but no documents 
+       will be returned in the first batch. 
 
        The following example query returns results in batches of
        100: 

--- a/source/reference/methods.txt
+++ b/source/reference/methods.txt
@@ -502,7 +502,7 @@ Cursor Methods
        size is ``101`` documents and subsequent batches have a maximum 
        size of 16 mebibytes (MiB). This option can enforce a smaller
        limit than 16 MiB, but not a larger one. If you set ``batchSize`` 
-       to a limit that results in batches larger than 16 MiB, this option has no effect and :method:`~cursor.batchSize()` uses the default batch size..
+       to a limit that results in batches larger than 16 MiB, this option has no effect and :method:`~cursor.batchSize()` uses the default batch size.
 
        A ``batchSize`` of ``0`` means that the cursor is established, but no documents 
        are returned in the first batch. 

--- a/source/reference/methods.txt
+++ b/source/reference/methods.txt
@@ -498,7 +498,7 @@ Cursor Methods
 
    * - :method:`cursor.batchSize()`
      - Specifies the maximum number of documents MongoDB will return to the client 
-       within each batch returned in a query result. By default, the initial batchx 
+       within each batch returned in a query result. By default, the initial batch
        size is ``101`` documents and subsequent batches have a maximum 
        size of 16 mebibytes (MiB). This option can enforce a smaller
        limit than 16 MiB, but not a larger one. If you set ``batchSize`` 

--- a/source/reference/methods.txt
+++ b/source/reference/methods.txt
@@ -498,14 +498,14 @@ Cursor Methods
 
    * - :method:`cursor.batchSize()`
      - Specifies the maximum number of documents MongoDB will return to the client 
-       within each batch returned in a query result. By default, the initial batch 
+       within each batch returned in a query result. By default, the initial batchx 
        size is ``101`` documents and subsequent batches have a maximum 
        size of 16 mebibytes (MiB). This option can enforce a smaller
        limit than 16 MiB, but not a larger one. If you set ``batchSize`` 
-       to a limit that results in batches larger than 16 MiB, this option has no effect.
+       to a limit that results in batches larger than 16 MiB, this option has no effect and :method:`~cursor.batchSize()` uses the default batch size..
 
-       A batchSize of 0 means that the cursor will be established, but no documents 
-       will be returned in the first batch. 
+       A ``batchSize`` of ``0`` means that the cursor is established, but no documents 
+       are returned in the first batch. 
 
        The following example query returns results in batches of
        100: 


### PR DESCRIPTION
## DESCRIPTION
Updates the reference/methods page to clarify how BatchSize works. Related to the [batchsize pr](https://github.com/mongodb/docs/pull/6292) in the docs repo. No new sections were added, but descriptions of BatchSize were changed.

Wording taken from already updated [PHP driver docs](https://jira.mongodb.org/browse/DOCSP-47835) which was approved by a PHP engineer. 

## STAGING
https://deploy-preview-392--docs-mongodb-shell.netlify.app/reference/methods/#cursor-methods

## JIRA
https://jira.mongodb.org/browse/DOCSP-47795

## BUILD LOG
https://app.netlify.com/sites/docs-mongodb-shell/deploys/67d4525e66989c0008faf1e8

## Self-Review Checklist

- [x] Is this free of any warnings or errors in the RST?
- [x] Is this free of spelling errors?
- [x] Is this free of grammatical errors?
- [x] Is this free of staging / rendering issues?
- [x] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)