### PR TITLE
DOCSP-47538-log-path-and-id

### DIFF
--- a/source/includes/log-file-location.rst
+++ b/source/includes/log-file-location.rst
@@ -1,0 +1,16 @@
+Starting in |mdb-shell| 2.4.0, you can also use the ``log.getPath()``
+command to view the current log file location. For example:
+
+.. code-block:: javascript
+
+   log.getPath()
+
+The output format depends on the operating system. Example output:
+
+.. code-block:: javascript
+   :copyable: false
+
+   /Users/jane.doe/.mongodb/mongosh/c2961dbd6b73b052671d9df0_log
+
+The hexadecimal value in the path is the ``mongosh`` log identifier for
+the current session.

--- a/source/includes/log-file-location.rst
+++ b/source/includes/log-file-location.rst
@@ -1,4 +1,4 @@
-Starting in |mdb-shell| 2.4.0, you can also use the ``log.getPath()``
+Starting in |mdb-shell| 2.4.0, you can use the ``log.getPath()``
 command to view the current log file location. For example:
 
 .. code-block:: javascript
@@ -12,5 +12,5 @@ The output format depends on the operating system. Example output:
 
    /Users/jane.doe/.mongodb/mongosh/c2961dbd6b73b052671d9df0_log
 
-The hexadecimal value in the path is the ``mongosh`` log identifier for
+The hexadecimal value in the path is the |mdb-shell| log identifier for
 the current session.

--- a/source/includes/log-file-location.rst
+++ b/source/includes/log-file-location.rst
@@ -5,7 +5,7 @@ command to view the current log file location. For example:
 
    log.getPath()
 
-The output format depends on the operating system. Example output:
+Example output:
 
 .. code-block:: javascript
    :copyable: false

--- a/source/logs/custom-entries.txt
+++ b/source/logs/custom-entries.txt
@@ -148,3 +148,7 @@ Output, which varies depending on your implementation:
    :copyable: false
 
    /.mongodb/mongosh/67ddc00703bcd2a490a7299f_log
+
+./mongosh --port 27019
+
+The hexadecimal value in the path is the ``mongosh`` log ID.

--- a/source/logs/custom-entries.txt
+++ b/source/logs/custom-entries.txt
@@ -18,13 +18,16 @@ script performs specific functions.
 About this Task
 ---------------
 
-MongoDB Shell supports the following methods for custom log entries:
+MongoDB Shell supports the following methods for setting the level for
+custom log entries:
 
 - ``log.debug()``
 - ``log.error()``
 - ``log.fatal()``
 - ``log.info()``
 - ``log.warn()``
+
+To view the log file location in the file system, use ``log.getPath()``.
 
 Steps
 -----
@@ -131,3 +134,17 @@ Output:
          genres: [ 'Drama', 'Romance', 'War' ]
       }
    ]
+
+The following example uses ``log.getPath()`` to view the log file
+location in the file system:
+
+.. code-block:: javascript
+
+   log.getPath()
+
+Output:
+
+.. code-block:: javascript
+   :copyable: false
+
+   /.mongodb/mongosh/67ddc00703bcd2a490a7299f_log

--- a/source/logs/custom-entries.txt
+++ b/source/logs/custom-entries.txt
@@ -27,9 +27,6 @@ custom log entries:
 - ``log.info()``
 - ``log.warn()``
 
-Starting in |mdb-shell| 2.4.0, you can view the log file location in the
-file system with the ``log.getPath()`` command.
-
 Steps
 -----
 
@@ -135,23 +132,3 @@ Output:
          genres: [ 'Drama', 'Romance', 'War' ]
       }
    ]
-
-The following example uses ``log.getPath()`` to view the log file
-location in the file system:
-
-.. code-block:: javascript
-
-   log.getPath()
-
-Example output:
-
-.. code-block:: javascript
-   :copyable: false
-
-   /Users/jane.doe/.mongodb/mongosh/67ddc00703bcd2a490a7299f_log
-
-./mongosh --port 27019
-
-The hexadecimal value in the path is the ``mongosh`` log identifier for
-the current session. In the previous example, the identifier is
-``67ddc00703bcd2a490a7299f``.

--- a/source/logs/custom-entries.txt
+++ b/source/logs/custom-entries.txt
@@ -18,8 +18,7 @@ script performs specific functions.
 About this Task
 ---------------
 
-MongoDB Shell supports the following methods for setting the level for
-custom log entries:
+MongoDB Shell supports the following methods for custom log entries:
 
 - ``log.debug()``
 - ``log.error()``

--- a/source/logs/custom-entries.txt
+++ b/source/logs/custom-entries.txt
@@ -27,7 +27,8 @@ custom log entries:
 - ``log.info()``
 - ``log.warn()``
 
-To view the log file location in the file system, use ``log.getPath()``.
+Starting in |mdb-shell| 2.4.0, you can view the log file location in the
+file system with the ``log.getPath()`` command.
 
 Steps
 -----
@@ -142,12 +143,12 @@ location in the file system:
 
    log.getPath()
 
-Output, which varies depending on your implementation:
+Example output:
 
 .. code-block:: javascript
    :copyable: false
 
-   /.mongodb/mongosh/67ddc00703bcd2a490a7299f_log
+   /Users/jane.doe/.mongodb/mongosh/67ddc00703bcd2a490a7299f_log
 
 ./mongosh --port 27019
 

--- a/source/logs/custom-entries.txt
+++ b/source/logs/custom-entries.txt
@@ -151,4 +151,6 @@ Output, which varies depending on your implementation:
 
 ./mongosh --port 27019
 
-The hexadecimal value in the path is the ``mongosh`` log ID.
+The hexadecimal value in the path is the ``mongosh`` log identifier for
+the current session. In the previous example, the identifier is
+``67ddc00703bcd2a490a7299f``.

--- a/source/logs/custom-entries.txt
+++ b/source/logs/custom-entries.txt
@@ -142,7 +142,7 @@ location in the file system:
 
    log.getPath()
 
-Output:
+Output, which varies depending on your implementation:
 
 .. code-block:: javascript
    :copyable: false

--- a/source/logs/location.txt
+++ b/source/logs/location.txt
@@ -37,6 +37,10 @@ To view the current log file location, use the :ref:`config API
 After you modify your log file location, you must start a new
 |mdb-shell| session for the change to take effect.
 
+Starting in |mdb-shell| 2.4.0, you can also use the ``log.getPath()``
+command to view the current log file location. For details, see
+:ref:`mongosh-custom-log-entries`.
+
 Log File Names
 ~~~~~~~~~~~~~~
 

--- a/source/logs/location.txt
+++ b/source/logs/location.txt
@@ -37,6 +37,9 @@ To view the current log file location, use the :ref:`config API
 After you modify your log file location, you must start a new
 |mdb-shell| session for the change to take effect.
 
+Log File Location
+~~~~~~~~~~~~~~~~~
+
 .. include:: /includes/log-file-location.rst
 
 Log File Names

--- a/source/logs/location.txt
+++ b/source/logs/location.txt
@@ -37,9 +37,7 @@ To view the current log file location, use the :ref:`config API
 After you modify your log file location, you must start a new
 |mdb-shell| session for the change to take effect.
 
-Starting in |mdb-shell| 2.4.0, you can also use the ``log.getPath()``
-command to view the current log file location. For details, see
-:ref:`mongosh-custom-log-entries`.
+.. include:: /includes/log-file-location.rst
 
 Log File Names
 ~~~~~~~~~~~~~~

--- a/source/logs/view.txt
+++ b/source/logs/view.txt
@@ -13,11 +13,11 @@ View Shell Logs
 The |mdb-shell| stores logs for each session. The default log location
 depends on your operating system.
 
-.. include:: /includes/log-file-location.rst
-
 .. include:: /includes/steps/view-logs.rst
 
 .. tip::
   
    To change where MongoDB Shell writes logs, see
    :ref:`mongosh-log-location`.
+
+.. include:: /includes/log-file-location.rst

--- a/source/logs/view.txt
+++ b/source/logs/view.txt
@@ -19,3 +19,7 @@ depends on your operating system.
   
    To change where MongoDB Shell writes logs, see
    :ref:`mongosh-log-location`.
+
+Starting in |mdb-shell| 2.4.0, you can use the ``log.getPath()``
+command to view the current log file location. For details, see
+:ref:`mongosh-custom-log-entries`.

--- a/source/logs/view.txt
+++ b/source/logs/view.txt
@@ -13,11 +13,11 @@ View Shell Logs
 The |mdb-shell| stores logs for each session. The default log location
 depends on your operating system.
 
+.. include:: /includes/log-file-location.rst
+
 .. include:: /includes/steps/view-logs.rst
 
 .. tip::
   
    To change where MongoDB Shell writes logs, see
    :ref:`mongosh-log-location`.
-
-.. include:: /includes/log-file-location.rst

--- a/source/logs/view.txt
+++ b/source/logs/view.txt
@@ -20,6 +20,4 @@ depends on your operating system.
    To change where MongoDB Shell writes logs, see
    :ref:`mongosh-log-location`.
 
-Starting in |mdb-shell| 2.4.0, you can use the ``log.getPath()``
-command to view the current log file location. For details, see
-:ref:`mongosh-custom-log-entries`.
+.. include:: /includes/log-file-location.rst


### PR DESCRIPTION
## DESCRIPTION

Starting in Mongo Shell 2.4.0, you can view the log file location in the
file system with the ``log.getPath()`` command, which also contains the session ID.

## STAGING

https://deploy-preview-395--docs-mongodb-shell.netlify.app/logs/view/#view-shell-logs

https://deploy-preview-395--docs-mongodb-shell.netlify.app/logs/location/#log-file-location

## JIRA

https://jira.mongodb.org/browse/DOCSP-47538

## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)