### PR TITLE
DOCSP-49854-remove-old-url

### DIFF
--- a/source/snippets/working-with-snippets.txt
+++ b/source/snippets/working-with-snippets.txt
@@ -211,9 +211,6 @@ The output lists each repository.
 .. code-block:: javascript
    :copyable: false
 
-   Snippet repository URL:      https://github.com/YOUR_COMPANY/YOUR_REPO_PATH/index.bson.br
-     -->  Homepage:             https://davemungo.github.io/mongosh-snippets/
-
    Snippet repository URL:      https://compass.mongodb.com/mongosh/snippets-index.bson.br
      -->  Homepage:             https://github.com/mongodb-labs/mongosh-snippets
 


### PR DESCRIPTION
## DESCRIPTION
Deleted the old URL that was linking to a personal GitHub repo.

## STAGING
https://deploy-preview-403--docs-mongodb-shell.netlify.app/snippets/working-with-snippets/

## JIRA
https://jira.mongodb.org/browse/DOCSP-49854

## BUILD LOG


## Self-Review Checklist

- [ ] Is this free of any warnings or errors in the RST?
- [ ] Is this free of spelling errors?
- [ ] Is this free of grammatical errors?
- [ ] Is this free of staging / rendering issues?
- [ ] Are all the links working?

## External Review Requirements

[What's expected of an external reviewer?](https://wiki.corp.mongodb.com/display/DE/Reviewing+Guidelines+for+the+MongoDB+Server+Documentation)